### PR TITLE
Fix in shared - Filter header position

### DIFF
--- a/frontend/libs/shared/layouts/GridFilterHeader.vue
+++ b/frontend/libs/shared/layouts/GridFilterHeader.vue
@@ -15,7 +15,7 @@ const slots = useSlots();
 </script>
 
 <template>
-  <div class="flex justify-content-start items-center">
+  <div class="flex justify-start items-center">
     <slot v-if="slots.settings" name="settings" />
     <span v-if="column.title" :class="{'ml-6': slots.settings}" class="mr-1">{{ column.title }}</span>
     <slot v-if="slots.filter" name="filter" />


### PR DESCRIPTION
There is not such thing as 'justify-content-start'. Changed it to 'justify-start'.