### PR TITLE
Feature in shared - Add slider for action buttons

### DIFF
--- a/frontend/libs/shared/components/TableActionButtons.vue
+++ b/frontend/libs/shared/components/TableActionButtons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import ExtraMenu from '@shared/components/disco/ExtraMenu.vue';
+import {useTableActionSlider} from '@shared/composables/useTableActionSlider';
 import {computed} from 'vue';
 
 interface Button {
@@ -13,22 +13,36 @@ interface Button {
 
 export interface TableActionButtonsProps {
   buttons: Button[];
-  variant?: 'normal' | 'minimal' | 'compact';
+  variant?: 'normal' | 'minimal' | 'compact' | 'slider';
 }
 const props = withDefaults(defineProps<TableActionButtonsProps>(), {
   variant: 'normal',
 });
 const emit = defineEmits<{
-  [key: string]: [];
+  slideOut: [value: number];
+  slideIn: [value: number];
+  [key: string]: [value?: number];
 }>();
 
 const shownButtons = computed(() => props.buttons.filter((button) => button.show ?? true));
 const outsideButtons = computed(() => shownButtons.value.slice(0, 1));
 const remainingButtons = computed(() => shownButtons.value.slice(1));
+
+const {sliderWidth, setupTableActionSlider, stopSlideInTimerAndSlideOut, startSlideInTimer} = useTableActionSlider();
+
+if (props.variant === 'slider') {
+  setupTableActionSlider(
+    () => emit('slideOut', sliderWidth.value),
+    () => emit('slideIn', sliderWidth.value),
+    props.buttons.length,
+  );
+}
 </script>
 
 <template>
-  <div class="flex justify-center items-center">
+  <div
+    class="flex items-center"
+    :class="{'justify-center': variant !== 'slider', 'justify-start': variant === 'slider'}">
     <!-- Minimal Variant: All buttons in an extra menu -->
     <template v-if="variant === 'minimal'">
       <ExtraMenu>
@@ -53,6 +67,39 @@ const remainingButtons = computed(() => shownButtons.value.slice(1));
           :color="button.color"
           :disabled="button.disabled"
           @clicked="emit(button.event)"></DIconButton>
+      </div>
+    </template>
+
+    <!-- Normal Variant: All buttons displayed -->
+    <template v-else-if="variant === 'slider'">
+      <div class="flex justify-start pl-8">
+        <v-btn
+          plain
+          size="small"
+          variant="text"
+          icon
+          color="primary"
+          class="size-10"
+          @click.stop
+          @mouseenter="stopSlideInTimerAndSlideOut"
+          @mouseleave="startSlideInTimer">
+          <v-icon>mdi-dots-horizontal</v-icon>
+          <Tooltip location="bottom" text="Actions"></Tooltip>
+        </v-btn>
+        <div
+          v-for="button in buttons"
+          :key="button.icon"
+          class="size-10"
+          @mouseenter="stopSlideInTimerAndSlideOut"
+          @mouseleave="startSlideInTimer">
+          <DIconButton
+            v-if="button.show ?? true"
+            :icon="button.icon"
+            :hint="button.hint"
+            :color="button.color"
+            :disabled="button.disabled"
+            @clicked="emit(button.event)"></DIconButton>
+        </div>
       </div>
     </template>
 
@@ -94,3 +141,14 @@ const remainingButtons = computed(() => shownButtons.value.slice(1));
     </template>
   </div>
 </template>
+
+<style lang="scss">
+.action-slider-table > .v-table > .v-table__wrapper > table {
+  > thead > tr > th:first-child {
+    transition: width ease-in-out 0.2s;
+  }
+  > tbody > tr > td:first-child {
+    padding-right: 0 !important;
+  }
+}
+</style>

--- a/frontend/libs/shared/composables/useTableActionSlider.ts
+++ b/frontend/libs/shared/composables/useTableActionSlider.ts
@@ -1,0 +1,91 @@
+import {useTableActionSliderStore} from '@shared/stores/tableActionSlider.store';
+import {storeToRefs} from 'pinia';
+import {computed, ref, watch} from 'vue';
+
+export const useTableActionSlider = () => {
+  // Need the store to have one timeout across all sliders
+  const tableActionSliderStore = useTableActionSliderStore();
+  const {slideInTimeout} = storeToRefs(tableActionSliderStore);
+
+  const baseWidth = ref<number>(100);
+  const buttonsLength = ref<number>(1);
+  const sliderWidth = ref<number>(baseWidth.value);
+  const slideInTimer = ref<number>(0);
+
+  const slideOutAction = ref<() => unknown>(() => {});
+  const slideInAction = ref<() => unknown>(() => {});
+
+  const setupTableActionSlider = (
+    newSlideOutAction: () => unknown,
+    newSlideInAction: () => unknown,
+    newButtonsLength?: number,
+    newBaseWidth?: number,
+  ) => {
+    if (newBaseWidth && newBaseWidth > baseWidth.value) {
+      baseWidth.value = newBaseWidth;
+    }
+
+    if (newButtonsLength && newButtonsLength > buttonsLength.value) {
+      buttonsLength.value = newButtonsLength;
+    }
+
+    if (newSlideOutAction) {
+      slideOutAction.value = newSlideOutAction;
+    }
+
+    if (newSlideInAction) {
+      slideInAction.value = newSlideInAction;
+    }
+  };
+
+  const expandedMaxWidth = computed(() => buttonsLength.value * 40 + baseWidth.value);
+
+  const startSlideInTimer = () => {
+    slideInTimer.value = 300;
+
+    if (slideInTimeout.value) {
+      clearTimeout(slideInTimeout.value);
+      slideInTimeout.value = null;
+    }
+
+    slideInTimeout.value = setTimeout(() => {
+      slideInTimer.value = 0;
+    }, slideInTimer.value);
+  };
+
+  const slideOut = () => {
+    sliderWidth.value = expandedMaxWidth.value;
+    slideOutAction.value();
+  };
+
+  const slideIn = () => {
+    sliderWidth.value = baseWidth.value;
+    slideInAction.value();
+  };
+
+  const stopSlideInTimerAndSlideOut = () => {
+    if (slideInTimeout.value) {
+      clearTimeout(slideInTimeout.value);
+      slideInTimeout.value = null;
+    }
+
+    slideOut();
+  };
+
+  watch(slideInTimer, () => {
+    if (slideInTimer.value === 0) {
+      slideIn();
+    }
+  });
+
+  return {
+    baseWidth,
+    sliderWidth,
+    expandedMaxWidth,
+    slideOut,
+    slideIn,
+    setupTableActionSlider,
+    startSlideInTimer,
+    stopSlideInTimerAndSlideOut,
+  };
+};

--- a/frontend/libs/shared/stores/tableActionSlider.store.ts
+++ b/frontend/libs/shared/stores/tableActionSlider.store.ts
@@ -1,0 +1,10 @@
+import {defineStore} from 'pinia';
+import {ref} from 'vue';
+
+export const useTableActionSliderStore = defineStore('tableActionSlider', () => {
+  const slideInTimeout = ref<ReturnType<typeof setTimeout> | null>(null);
+
+  return {
+    slideInTimeout,
+  };
+});


### PR DESCRIPTION
Slider functionality for action buttons. Not yet used by any grid.

<img width="413" height="314" alt="image" src="https://github.com/user-attachments/assets/b0f004b7-7b24-4eb8-8dcd-cda70c292f7a" />

<img width="416" height="341" alt="image" src="https://github.com/user-attachments/assets/e48dffb0-1ea3-49ab-b257-4a09680c441d" />
