### PR TITLE
fix(keycloak): bind keycloak to 127.0.0.1 to allow http connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
     command: start-dev --health-enabled=true
     ports:
-      - 8080:8080
+      - 127.0.0.1:8080:8080
     volumes:
       - keycloak_data:/opt/keycloak/data
     healthcheck:


### PR DESCRIPTION
Keycloak only allows connections via HTTP by default, when accessing via a so called local IP address (e.g. `127.0.0.1`). 
When just specying a port (like 8080:8080) on macOS there is some magic happening which proxies requests and keycloak then thinks this is an external requests and blocks access: 
<img width="707" height="418" alt="grafik" src="https://github.com/user-attachments/assets/3af3e7c3-df05-42d1-a801-413d532e0ec8" />
 
I found some options to overcome this in a different project (https://github.com/quarkusio/quarkus/discussions/48905), which boil down to four options: 
- Adjust the docker Desktop settings on macOS to not use magic proxying and rather "host networking", which seems to be not the default
- Explictly bind the keycloak server to `127.0.0.1` to only be exposed via localhost
- Run `./kcadm.sh update realms/master -s sslRequired=NONE` to disable the SSL requirement (maybe as part of the `./import/setup-keycloak.sh` script
- Use the existing (dummy) SSL-certificates for disuku as well for keycloak

In this PR I opted for the second option, as this is somethig which project can do and from my perspective has no disadvantage for the local setup. Requiring local changes can be annoying, especially as this might have impact on other things. Disabling the SSL requirement centrally probably leads users to do that in production as well, which is not great and using the SSL-certifactes for keycloak as well would be an alternative approach, which I haven't explored in detail yet.

After swichting to `127.0.0.1:8080:8080` it worked out the box and I was able to access disuku.