### PR TITLE
feat: Refactor sbom logic in frontend

### DIFF
--- a/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
+++ b/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
@@ -8,8 +8,8 @@ import {ComponentLicenses} from '@disclosure-portal/model/Project';
 import {ComponentInfoSlim} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {useUserStore} from '@disclosure-portal/stores/user';
 import useRules from '@disclosure-portal/utils/Rules';
 import {getIconColorForPolicyType, getIconForPolicyType} from '@disclosure-portal/utils/View';
@@ -29,7 +29,7 @@ interface LicenseItemWithPolicyStatus {
 const {t} = useI18n();
 const {info} = useSnackbar();
 const rules = useRules();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const userStore = useUserStore();
 const emit = defineEmits(['reload']);
 const projectStore = useProjectStore();
@@ -58,10 +58,10 @@ const config = ref<DialogLicenseRuleConfig>({
 });
 
 const projectKey = computed(() => projectStore.currentProject!._key);
-const currentVersionId = computed(() => appStore.getCurrentVersion._key);
-const currentSbomId = computed(() => appStore.getSelectedSpdx._key);
-const currentSbomName = computed(() => appStore.getSelectedSpdx.MetaInfo.Name);
-const currentSbomUploaded = computed(() => appStore.getSelectedSpdx.Uploaded);
+const currentVersionId = computed(() => sbomStore.getCurrentVersion._key);
+const currentSbomId = computed(() => sbomStore.getSelectedSpdx._key);
+const currentSbomName = computed(() => sbomStore.getSelectedSpdx.MetaInfo.Name);
+const currentSbomUploaded = computed(() => sbomStore.getSelectedSpdx.Uploaded);
 
 const policyTypeMap = computed(() => {
   const statuses = config.value.policyStatus ?? [];

--- a/frontend/libs/portal/components/dialog/OverallAuditDialog.vue
+++ b/frontend/libs/portal/components/dialog/OverallAuditDialog.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import {OverallReviewRequest, OverallReviewState, SpdxFile} from '@disclosure-portal/model/VersionDetails';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime, getOverallReviewTranslationKey} from '@disclosure-portal/utils/Table';
 import DCActionButton from '@shared/components/disco/DCActionButton.vue';
@@ -24,8 +24,8 @@ export default defineComponent({
     const {minMax} = useRules();
     const {t} = useI18n();
     const {info: snack} = useSnackbar();
-    const appStore = useAppStore();
     const projectStore = useProjectStore();
+    const sbomStore = useSbomStore();
     const isVisible = ref(false);
     const selectedState = ref<OverallReviewState>(OverallReviewState.AUDITED);
     const selectedSBOM = ref<SpdxFile | null>(null);
@@ -85,7 +85,7 @@ export default defineComponent({
           }
           await versionService.createOverallReview(prId.value, vId.value, req); // Replace with actual IDs
           await projectStore.fetchProjectByKey(projectStore.currentProject!._key);
-          appStore.resetCurrentVersion();
+          sbomStore.resetCurrentVersion();
           emit('reload');
           close();
           snack(t('DIALOG_overallreview_create_success'));

--- a/frontend/libs/portal/components/dialog/OverallReviewDialog.vue
+++ b/frontend/libs/portal/components/dialog/OverallReviewDialog.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import {OverallReviewRequest, OverallReviewState, SpdxFile} from '@disclosure-portal/model/VersionDetails';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime, getOverallReviewTranslationKey} from '@disclosure-portal/utils/Table';
 import DCActionButton from '@shared/components/disco/DCActionButton.vue';
@@ -23,7 +23,7 @@ export default defineComponent({
     const {t} = useI18n();
     const {info: snack} = useSnackbar();
     const projectStore = useProjectStore();
-    const appStore = useAppStore();
+    const sbomStore = useSbomStore();
     const isVisible = ref(false);
     const selectedState = ref<OverallReviewState>(OverallReviewState.UNREVIEWED);
     const selectedSBOM = ref<SpdxFile | null>(null);
@@ -87,8 +87,8 @@ export default defineComponent({
         }
         await versionService.createOverallReview(prId.value, vId.value, req); // Replace with actual IDs
         await projectStore.fetchProjectByKey(projectStore.currentProject!._key);
-        await appStore.fetchSBOMHistory();
-        appStore.resetCurrentVersion();
+        await sbomStore.fetchSBOMHistory();
+        sbomStore.resetCurrentVersion();
         emit('reload');
         close();
         snack(t('DIALOG_overallreview_create_success'));

--- a/frontend/libs/portal/components/dialog/ReviewRemarkDialog.vue
+++ b/frontend/libs/portal/components/dialog/ReviewRemarkDialog.vue
@@ -59,10 +59,12 @@ const licenses = computed((): LicenseMeta[] => {
   if (!sbomAllLicenses.value) {
     return [];
   }
-  const known = sbomAllLicenses.value.known.map((license) => ({
-    licenseId: license.id,
-    licenseName: license.name,
-  }));
+  const known = sbomAllLicenses.value.known
+    ? sbomAllLicenses.value.known.map((license) => ({
+        licenseId: license.id,
+        licenseName: license.name,
+      }))
+    : [];
   const unknown = sbomAllLicenses.value.unknown
     ? sbomAllLicenses.value.unknown.map((str) => ({licenseId: str, licenseName: str}))
     : [];

--- a/frontend/libs/portal/components/dialog/ReviewRemarkDialog.vue
+++ b/frontend/libs/portal/components/dialog/ReviewRemarkDialog.vue
@@ -6,8 +6,8 @@ import {ReviewTemplate} from '@disclosure-portal/model/ReviewTemplate';
 import {ComponentInfoSlim, SpdxFile} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import DialogLayout, {DialogLayoutConfig} from '@shared/layouts/DialogLayout.vue';
@@ -20,7 +20,7 @@ import {VForm} from 'vuetify/components';
 const level: ReviewRemarkLevel[] = [ReviewRemarkLevel.GREEN, ReviewRemarkLevel.YELLOW, ReviewRemarkLevel.RED];
 
 const {t} = useI18n();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const projectStore = useProjectStore();
 const {minMax} = useRules();
 const {info: snack} = useSnackbar();
@@ -71,7 +71,7 @@ const licenses = computed((): LicenseMeta[] => {
 });
 
 const projectModel = computed((): Project => projectStore.currentProject!);
-const version = computed(() => appStore.getCurrentVersion);
+const version = computed(() => sbomStore.getCurrentVersion);
 const versionID = computed(() => config.value.versionID || version.value._key);
 
 const dialogConfig = computed((): DialogLayoutConfig => {

--- a/frontend/libs/portal/components/dialog/VersionDialogForm.vue
+++ b/frontend/libs/portal/components/dialog/VersionDialogForm.vue
@@ -2,8 +2,8 @@
 import {DialogVersionFormConfig} from '@disclosure-portal/components/dialog/DialogConfigs';
 import ProjectVersionPostRequest from '@disclosure-portal/model/ProjectVersionPostRequest';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {DiscoForm} from '@disclosure-portal/types/discobasics';
 import useRules from '@disclosure-portal/utils/Rules';
 import useSnackbar from '@shared/composables/useSnackbar';
@@ -11,7 +11,7 @@ import {computed, nextTick, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 
 const {t} = useI18n();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const projectStore = useProjectStore();
 const {info: snack} = useSnackbar();
 const {minMax, longText} = useRules();
@@ -59,7 +59,7 @@ const doDialogAction = async () => {
     snack(t('DIALOG_version_create_success'));
   }
   await projectStore.fetchProjectByKey(config.value.projectID);
-  appStore.resetCurrentVersion();
+  sbomStore.resetCurrentVersion();
   versionDialog.value?.reset();
   isVisible.value = false;
 };

--- a/frontend/libs/portal/components/dialog/checklist/ChecklistExecuteDialog.vue
+++ b/frontend/libs/portal/components/dialog/checklist/ChecklistExecuteDialog.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import {Checklist} from '@disclosure-portal/model/Checklist';
 import projectService from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {DiscoForm} from '@disclosure-portal/types/discobasics';
 import useSnackbar from '@shared/composables/useSnackbar';
 import {computed, nextTick, ref} from 'vue';
@@ -12,10 +12,10 @@ import {useRoute} from 'vue-router';
 const {t} = useI18n();
 const {info: snack} = useSnackbar();
 const route = useRoute();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 
 const currentProject = computed(() => useProjectStore().currentProject!);
-const version = computed(() => appStore.getCurrentVersion);
+const version = computed(() => sbomStore.getCurrentVersion);
 const sbom = computed(() =>
   Array.isArray(route.params.currentSbom) ? route.params.currentSbom[0] : route.params.currentSbom,
 );

--- a/frontend/libs/portal/components/dialog/project/RequestApproval.vue
+++ b/frontend/libs/portal/components/dialog/project/RequestApproval.vue
@@ -7,10 +7,9 @@ import {UserDto} from '@disclosure-portal/model/Users';
 import {ComponentStats, SpdxFile, VersionSlim} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
-import {useJobStore} from '@disclosure-portal/stores/jobs';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
@@ -22,7 +21,7 @@ import {useI18n} from 'vue-i18n';
 import {VForm} from 'vuetify/components';
 
 const projectStore = useProjectStore();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const {longText} = useRules();
 const {t} = useI18n();
 const snackbar = useSnackbar();
@@ -216,8 +215,8 @@ const autoSelect = async () => {
     selectedChannel.value =
       channels.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.versionkey) ?? null;
   }
-  if (Object.keys(appStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
-    selectedChannel.value = appStore.currentVersion;
+  if (Object.keys(sbomStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
+    selectedChannel.value = sbomStore.currentVersion;
   }
   if (selectedChannel.value) {
     await loadSBOMHist();
@@ -227,7 +226,7 @@ const autoSelect = async () => {
     selectedSbom.value =
       sboms.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.spdxkey) ?? null;
     if (selectedSbom.value === null) {
-      selectedSbom.value = appStore.selectedSpdx ?? null;
+      selectedSbom.value = sbomStore.selectedSpdx ?? null;
     }
     await loadStats();
   }

--- a/frontend/libs/portal/components/dialog/project/RequestApproval.vue
+++ b/frontend/libs/portal/components/dialog/project/RequestApproval.vue
@@ -8,6 +8,7 @@ import {ComponentStats, SpdxFile, VersionSlim} from '@disclosure-portal/model/Ve
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
+import {useJobStore} from '@disclosure-portal/stores/jobs';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';

--- a/frontend/libs/portal/components/dialog/project/RequestFOSSDD.vue
+++ b/frontend/libs/portal/components/dialog/project/RequestFOSSDD.vue
@@ -5,10 +5,10 @@ import {ApprovableInfoDto, ApprovableSPDXDto} from '@disclosure-portal/model/Pro
 import {ComponentStats, OverallReviewState, SpdxFile, VersionSlim} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
-import {useJobStore} from '@disclosure-portal/stores/jobs';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useJobStore} from '@disclosure-portal/stores/jobs';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import config from '@shared/utils/config';
@@ -18,7 +18,7 @@ import {useI18n} from 'vue-i18n';
 import {VForm} from 'vuetify/components';
 
 const projectStore = useProjectStore();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const {longText} = useRules();
 const {t} = useI18n();
 const idle = useIdleStore();
@@ -304,8 +304,8 @@ const autoSelect = async () => {
     selectedChannel.value =
       channels.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.versionkey) ?? null;
   }
-  if (Object.keys(appStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
-    selectedChannel.value = appStore.currentVersion;
+  if (Object.keys(sbomStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
+    selectedChannel.value = sbomStore.currentVersion;
   }
   if (selectedChannel.value) {
     await loadSBOMHist();
@@ -315,7 +315,7 @@ const autoSelect = async () => {
     selectedSbom.value =
       sboms.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.spdxkey) ?? null;
     if (selectedSbom.value === null) {
-      selectedSbom.value = appStore.selectedSpdx ?? null;
+      selectedSbom.value = sbomStore.selectedSpdx ?? null;
     }
     await loadStats();
   }

--- a/frontend/libs/portal/components/dialog/project/RequestReview.vue
+++ b/frontend/libs/portal/components/dialog/project/RequestReview.vue
@@ -6,9 +6,9 @@ import {ComponentStats, SpdxFile, VersionSlim} from '@disclosure-portal/model/Ve
 import profileService from '@disclosure-portal/services/profile';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import DAutocompleteUser from '@shared/components/disco/DAutocompleteUser.vue';
@@ -19,7 +19,7 @@ import {useI18n} from 'vue-i18n';
 import {VForm} from 'vuetify/components';
 
 const projectStore = useProjectStore();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const {longText} = useRules();
 const {t} = useI18n();
 const snackbar = useSnackbar();
@@ -120,8 +120,8 @@ const autoSelect = async () => {
     return;
   }
 
-  if (Object.keys(appStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
-    selectedChannel.value = appStore.currentVersion;
+  if (Object.keys(sbomStore.selectedSpdx).length > 0 && !projectModel.value.isGroup) {
+    selectedChannel.value = sbomStore.currentVersion;
   } else {
     selectedChannel.value =
       channels.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.versionkey) ?? null;
@@ -133,8 +133,8 @@ const autoSelect = async () => {
     }
     selectedSbom.value =
       sboms.value.find((a) => a._key === approvableInfo.value.projects[0].approvablespdx.spdxkey) ?? null;
-    if (Object.keys(appStore.selectedSpdx).length > 0) {
-      selectedSbom.value = appStore.selectedSpdx ?? null;
+    if (Object.keys(sbomStore.selectedSpdx).length > 0) {
+      selectedSbom.value = sbomStore.selectedSpdx ?? null;
     }
     await loadStats();
   }

--- a/frontend/libs/portal/components/grids/GridReviewRemarks.vue
+++ b/frontend/libs/portal/components/grids/GridReviewRemarks.vue
@@ -12,8 +12,8 @@ import {
 import type {BulkSetReviewRemarkStatusRequest} from '@disclosure-portal/model/ReviewRemarkBulkOperations';
 import {default as ProjectService} from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {downloadFile} from '@disclosure-portal/utils/download';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {getIconColorReviewRemarkLevel, getIconReviewRemarkLevel} from '@disclosure-portal/utils/View';
@@ -29,7 +29,7 @@ import {computed, onMounted, ref, watch} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRoute} from 'vue-router';
 
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const projectStore = useProjectStore();
 const route = useRoute();
 const {t} = useI18n();
@@ -73,7 +73,7 @@ const bulkCancelVisible = ref(false);
 const lists = ref<Checklist[]>([]);
 
 const projectModel = computed((): Project => projectStore.currentProject!);
-const version = computed(() => appStore.getCurrentVersion);
+const version = computed(() => sbomStore.getCurrentVersion);
 const checklistAvailable = computed(() => lists.value.length > 0);
 
 const possibleLevel = computed((): DataTableHeaderFilterItems[] => {

--- a/frontend/libs/portal/components/grids/GridSBOM.vue
+++ b/frontend/libs/portal/components/grids/GridSBOM.vue
@@ -14,6 +14,7 @@ import versionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {formatDateTime, formatDateTimeShort, originShort, originTooltip} from '@disclosure-portal/utils/View';
@@ -48,14 +49,15 @@ const emit = defineEmits(['openVersion']);
 const {t} = useI18n();
 const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const route = useRoute();
 const router = useRouter();
 const idle = useIdleStore();
 const {copyToClipboard} = useClipboard();
 
 const projectModel = computed(() => projectStore.currentProject!);
-const versionDetails = computed(() => appStore.getCurrentVersion);
-const spdxFileHistory = computed(() => appStore.getChannelSpdxs);
+const versionDetails = computed(() => sbomStore.getCurrentVersion);
+const spdxFileHistory = computed(() => sbomStore.getChannelSpdxs);
 const labelTools = computed(() => appStore.getLabelsTools);
 
 const search = ref('');
@@ -172,7 +174,7 @@ const items = computed((): DataTableItems[] => {
   };
 
   if (!props.channelView) {
-    return appStore.getAllSBOMsFlat.map((file) => ({
+    return sbomStore.getAllSBOMsFlat.map((file) => ({
       ...file,
       searchIndex: getSearchIndex(file),
     }));
@@ -255,10 +257,10 @@ const reloadSboms = async () => {
     if (spdxFileHistory[0]) {
       spdxFileHistory[0].isRecent = true;
     }
-    appStore.setChannelSpdxs(spdxFileHistory);
-    await appStore.fetchAllSBOMs();
+    sbomStore.setChannelSpdxs(spdxFileHistory);
+    await sbomStore.fetchAllSBOMs();
   } else {
-    await appStore.fetchAllSBOMsFlat();
+    await sbomStore.fetchAllSBOMsFlat();
   }
 };
 const toggleLock = async (item: VersionSbomsFlat) => {
@@ -278,7 +280,7 @@ const setApprovable = async (item: VersionSbomsFlat) => {
   await projectService
     .updateApprovableSpdx(approvableSpdx, projectModel.value._key)
     .then(() => (projectModel.value.approvablespdx = approvableSpdx));
-  await appStore.fetchAllSBOMs();
+  await sbomStore.fetchAllSBOMs();
 };
 const downloadFile = (item: VersionSbomsFlat) => {
   const link = document.createElement('a');
@@ -302,8 +304,8 @@ const downloadFile = (item: VersionSbomsFlat) => {
 
 onMounted(async () => {
   if (!props.channelView) {
-    appStore.fetchAllSBOMsFlat().then(() => {
-      branches.value = appStore.allVersions;
+    sbomStore.fetchAllSBOMsFlat().then(() => {
+      branches.value = sbomStore.allVersions;
       selectedBranch.value = branches.value[0];
       if (versionDetails.value) {
         const branchFromVersion = branches.value.find((g) => g.key == versionDetails.value._key);

--- a/frontend/libs/portal/components/projects/policyDecision/BulkPolicyDecisionsDialog.vue
+++ b/frontend/libs/portal/components/projects/policyDecision/BulkPolicyDecisionsDialog.vue
@@ -8,8 +8,8 @@ import ErrorDialog from '@disclosure-portal/components/dialog/ErrorDialog.vue';
 import ErrorDialogConfig from '@disclosure-portal/model/ErrorDialogConfig';
 import {PolicyDecisionRequest} from '@disclosure-portal/model/PolicyDecision';
 import projectService from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {useUserStore} from '@disclosure-portal/stores/user';
 import useRules from '@disclosure-portal/utils/Rules';
 import {escapeHtml} from '@disclosure-portal/utils/Validation';
@@ -23,7 +23,6 @@ import {DataTableHeader} from '@shared/types/table';
 import {computed, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {VForm} from 'vuetify/components';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
 
 type TableItem = DialogBulkPolicyDecisionEntry & {
   key: string;
@@ -32,7 +31,7 @@ type TableItem = DialogBulkPolicyDecisionEntry & {
 const {t} = useI18n();
 const {info} = useSnackbar();
 const rules = useRules();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const userStore = useUserStore();
 const emit = defineEmits(['reload']);
 const projectStore = useProjectStore();
@@ -99,10 +98,11 @@ const headers: DataTableHeader[] = [
 ];
 
 const projectKey = computed(() => projectStore.currentProject!._key);
-const currentVersionKey = computed(() => appStore.getCurrentVersion._key);
-const currentSbomId = computed(() => appStore.getSelectedSpdx._key);
-const currentSbomName = computed(() => appStore.getSelectedSpdx.MetaInfo.Name);
-const currentSbomUploaded = computed(() => appStore.getSelectedSpdx.Uploaded);
+const currentVersionKey = computed(() => sbomStore.getCurrentVersion._key);
+const currentSbomId = computed(() => sbomStore.getSelectedSpdx._key);
+const currentSbomName = computed(() => sbomStore.getSelectedSpdx.MetaInfo.Name);
+const currentSbomUploaded = computed(() => sbomStore.getSelectedSpdx.Uploaded);
+
 const buttonsDisabled = computed(() => !verification.value || selected.value.length === 0);
 
 const open = async (

--- a/frontend/libs/portal/components/projects/policyDecision/PolicyDecisionDialog.vue
+++ b/frontend/libs/portal/components/projects/policyDecision/PolicyDecisionDialog.vue
@@ -5,8 +5,8 @@ import ErrorDialogConfig from '@disclosure-portal/model/ErrorDialogConfig';
 import {PolicyDecisionRequest} from '@disclosure-portal/model/PolicyDecision';
 import {ComponentInfoSlim, PolicyRuleStatus} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {useUserStore} from '@disclosure-portal/stores/user';
 import useRules from '@disclosure-portal/utils/Rules';
 import {getIconColorForPolicyType, getIconForPolicyType} from '@disclosure-portal/utils/View';
@@ -20,7 +20,7 @@ import {DialogPolicyDecisionConfig} from '@disclosure-portal/components/dialog/D
 const {t} = useI18n();
 const {info} = useSnackbar();
 const rules = useRules();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const userStore = useUserStore();
 const emit = defineEmits(['reload', 'triggerBulk']);
 const projectStore = useProjectStore();
@@ -44,10 +44,10 @@ const config = ref<DialogPolicyDecisionConfig>({
 });
 
 const projectKey = computed(() => projectStore.currentProject!._key);
-const currentVersionKey = computed(() => appStore.getCurrentVersion._key);
-const currentSbomId = computed(() => appStore.getSelectedSpdx._key);
-const currentSbomName = computed(() => appStore.getSelectedSpdx.MetaInfo.Name);
-const currentSbomUploaded = computed(() => appStore.getSelectedSpdx.Uploaded);
+const currentVersionKey = computed(() => sbomStore.getCurrentVersion._key);
+const currentSbomId = computed(() => sbomStore.getSelectedSpdx._key);
+const currentSbomName = computed(() => sbomStore.getSelectedSpdx.MetaInfo.Name);
+const currentSbomUploaded = computed(() => sbomStore.getSelectedSpdx.Uploaded);
 
 const selectedComponent = computed(() => config.value.component);
 const policies = computed(() => config.value.policies);

--- a/frontend/libs/portal/components/projects/projectsVersions/TabAuditLog.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabAuditLog.vue
@@ -2,14 +2,14 @@
 import GridAuditLog from '@disclosure-portal/components/grids/GridAuditLog.vue';
 import ProjectService from '@disclosure-portal/services/projects';
 import VersionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {computed} from 'vue';
 
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 
 const currentProject = computed(() => useProjectStore().currentProject!);
-const currentVersionId = computed(() => appStore.getCurrentVersion._key);
+const currentVersionId = computed(() => sbomStore.getCurrentVersion._key);
 const currentProjectId = computed(() => currentProject.value._key!);
 
 const fetchMethod = () => {

--- a/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
@@ -12,9 +12,9 @@ import {
 } from '@disclosure-portal/model/VersionDetails';
 import ProjectService from '@disclosure-portal/services/projects';
 import VersionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {escapeHtml} from '@disclosure-portal/utils/Validation';
@@ -41,8 +41,8 @@ type TabelItem = ComponentInfo & {
 const route = useRoute();
 const {t} = useI18n();
 const {getI18NTextOfPrefixKey} = useLicense();
-const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const idle = useIdleStore();
 
 const gridName = 'ComponentList';
@@ -50,9 +50,9 @@ const headerSettingsStore = useHeaderSettingsStore();
 const {filteredHeaders} = storeToRefs(headerSettingsStore);
 
 const projectModel = computed(() => projectStore.currentProject!);
-const versionDetails = computed(() => appStore.getCurrentVersion);
-const spdxFileHistory = computed(() => appStore.getChannelSpdxs);
-const currentSpdx = computed(() => appStore.getSelectedSpdx);
+const versionDetails = computed(() => sbomStore.getCurrentVersion);
+const spdxFileHistory = computed(() => sbomStore.getChannelSpdxs);
+const currentSpdx = computed(() => sbomStore.getSelectedSpdx);
 
 const search = ref('');
 const sortBy = ref<SortItem[]>([{key: 'prStatus', order: 'desc'}]);

--- a/frontend/libs/portal/components/projects/projectsVersions/TabNoticeFile.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabNoticeFile.vue
@@ -5,6 +5,7 @@ import ProjectService from '@disclosure-portal/services/projects';
 import VersionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {downloadFile, getIconColorScanRemarkLevel} from '@disclosure-portal/utils/View';
 import {TOOLTIP_OPEN_DELAY_IN_MS} from '@shared/utils/constant';
 import {computed, nextTick, onMounted, ref, watch} from 'vue';
@@ -15,11 +16,12 @@ import {VIcon} from 'vuetify/components';
 const {t} = useI18n();
 const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const currentProject = computed(() => projectStore.currentProject!);
-const currentVersionId = computed(() => appStore.getCurrentVersion._key);
+const currentVersionId = computed(() => sbomStore.getCurrentVersion._key);
 const currentProjectId = computed(() => currentProject.value._key);
-const spdx = computed(() => appStore.selectedSpdx);
-const spdxFileHistory = computed(() => appStore.getChannelSpdxs);
+const spdx = computed(() => sbomStore.selectedSpdx);
+const spdxFileHistory = computed(() => sbomStore.getChannelSpdxs);
 const labelTools = computed(() => appStore.getLabelsTools);
 const isVehicleProject = computed(() =>
   currentProject.value.policyLabels.some(

--- a/frontend/libs/portal/components/projects/projectsVersions/TabOverallReviews.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabOverallReviews.vue
@@ -2,9 +2,9 @@
 import useDimensions from '@disclosure-portal/composables/useDimensions';
 import {PolicyLabels} from '@disclosure-portal/constants/policyLabels';
 import {OverallReview, OverallReviewState} from '@disclosure-portal/model/VersionDetails';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useLabelStore} from '@disclosure-portal/stores/label.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {RightsUtils} from '@disclosure-portal/utils/Rights';
 import {formatDateAndTime, getIconColor, getVersionStateIcon} from '@disclosure-portal/utils/Table';
@@ -13,9 +13,9 @@ import {computed, nextTick, onMounted, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 
 const {t} = useI18n();
-const appStore = useAppStore();
 const labelStore = useLabelStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const {calculateHeight} = useDimensions();
 
 const sortBy: SortItem[] = [{key: 'created', order: 'desc'}];
@@ -26,9 +26,9 @@ const overallReviewDialog = ref();
 const overallAuditDialog = ref();
 
 const currentProject = computed(() => projectStore.currentProject!);
-const spdxHistory = computed(() => appStore.getChannelSpdxs);
-const selectedSpdx = computed(() => appStore.getSelectedSpdx);
-const version = computed(() => appStore.getCurrentVersion);
+const spdxHistory = computed(() => sbomStore.getChannelSpdxs);
+const selectedSpdx = computed(() => sbomStore.getSelectedSpdx);
+const version = computed(() => sbomStore.getCurrentVersion);
 const hasVehiclePlatformChildren = computed(() => projectStore.hasVehiclePlatformChildren);
 
 const isVehiclePlatform = computed(() => {

--- a/frontend/libs/portal/components/projects/projectsVersions/TabSBOMCompare.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabSBOMCompare.vue
@@ -10,8 +10,8 @@ import {
   PolicyRuleStatus,
 } from '@disclosure-portal/model/VersionDetails';
 import ProjectService from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {escapeHtml} from '@disclosure-portal/utils/Validation';
 import {
   getIconColorForPolicyType,
@@ -106,11 +106,11 @@ class CellValueWithLicenseInformation {
 }
 
 const currentProject = computed(() => useProjectStore().currentProject!);
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const {t} = useI18n();
 
-const version = computed(() => appStore.getCurrentVersion);
-const allSboms = computed(() => appStore.getAllSBOMs);
+const version = computed(() => sbomStore.getCurrentVersion);
+const allSboms = computed(() => sbomStore.getAllSBOMs);
 const groupedSpdxs = computed(() => {
   const res: SpdxIdentifier[] = [];
   allSboms.value.forEach((vs) => {
@@ -391,7 +391,7 @@ const reloadInternal = async (forceReload: boolean) => {
   if (!currentProject.value._key) {
     return;
   }
-  await appStore.fetchAllSBOMs();
+  await sbomStore.fetchAllSBOMs();
   selectedFilterLicenses.value = [];
   resetErrors();
 
@@ -399,7 +399,7 @@ const reloadInternal = async (forceReload: boolean) => {
 };
 
 const setSelection = () => {
-  const selectedSpdx = appStore.getSelectedSpdx;
+  const selectedSpdx = sbomStore.getSelectedSpdx;
   if (selectedSpdx === null) {
     selectedSpdxCurrent.value = groupedSpdxs.value.find((s) => s.versionKey === version.value._key) || null;
   } else {

--- a/frontend/libs/portal/components/projects/projectsVersions/TabSBOMQualityMain.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabSBOMQualityMain.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import {useAppStore} from '@disclosure-portal/stores/app';
+import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import Stack from '@shared/layouts/Stack.vue';
 import TableLayout from '@shared/layouts/TableLayout.vue';
 import {computed, defineAsyncComponent, ref, watch} from 'vue';
@@ -30,7 +31,7 @@ const componentMap: Record<string, ReturnType<typeof defineAsyncComponent>> = {
 
 const route = useRoute();
 const router = useRouter();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 const {t} = useI18n();
 
 const tabs = ref<QualityTab[]>([
@@ -82,7 +83,7 @@ const reload = () => {
   }
 };
 
-const version = appStore.getCurrentVersion;
+const version = sbomStore.getCurrentVersion;
 
 const changeTab = (currentTab: QualityTab, query = '') => {
   const tabName = 'sbomQuality';

--- a/frontend/libs/portal/components/projects/projectsVersions/TabSourceCode.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabSourceCode.vue
@@ -5,6 +5,7 @@ import {ExternalSource} from '@disclosure-portal/model/VersionDetails';
 import VersionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {formatDateTimeShort, getStrWithMaxLength} from '@disclosure-portal/utils/View';
@@ -19,6 +20,7 @@ import {useI18n} from 'vue-i18n';
 
 const appStore = useAppStore();
 const currentProject = computed(() => useProjectStore().currentProject!);
+const sbomStore = useSbomStore();
 const {t} = useI18n();
 const snackbar = useSnackbar();
 const {copyToClipboard} = useClipboard();
@@ -35,7 +37,7 @@ const tableHeight = ref(0);
 const scGrid = ref<HTMLElement | null>(null);
 
 const labelTools = computed(() => appStore.getLabelsTools);
-const version = computed(() => appStore.currentVersion);
+const version = computed(() => sbomStore.currentVersion);
 const headersSources = computed<DataTableHeader[]>(() => {
   return [
     {

--- a/frontend/libs/portal/components/projects/projectsVersions/charts/TabOverview.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/charts/TabOverview.vue
@@ -12,8 +12,8 @@ import {
   ScanRemarkStats,
 } from '@disclosure-portal/model/VersionDetails';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {getColor, getColorRGB} from '@disclosure-portal/utils/Tools';
 import {
   ArcElement,
@@ -52,13 +52,13 @@ type ChartData = {
 const {t} = useI18n();
 const router = useRouter();
 const route = useRoute();
-const appStore = useAppStore();
+const sbomStore = useSbomStore();
 applyChartDefaults();
 
 const projectModel = computed(() => useProjectStore().currentProject);
-const versionDetails = computed(() => appStore.getCurrentVersion);
-const spdxFileHistory = computed(() => appStore.getChannelSpdxs);
-const currentSpdx = computed(() => appStore.getSelectedSpdx);
+const versionDetails = computed(() => sbomStore.getCurrentVersion);
+const spdxFileHistory = computed(() => sbomStore.getChannelSpdxs);
+const currentSpdx = computed(() => sbomStore.getSelectedSpdx);
 const sbomStats = ref<SbomStats>({} as SbomStats);
 const generalStats = ref<GeneralStats>({} as GeneralStats);
 const policyStateStats = ref<ComponentStats>({} as ComponentStats);

--- a/frontend/libs/portal/components/projects/projectsVersions/charts/TabOverview.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/charts/TabOverview.vue
@@ -34,6 +34,7 @@ import {Bar, Doughnut} from 'vue-chartjs';
 import {useI18n} from 'vue-i18n';
 import {useRoute, useRouter} from 'vue-router';
 import {applyChartDefaults} from './ChartSettings';
+import {useAppStore} from '@disclosure-portal/stores/app';
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, ArcElement, CategoryScale, LinearScale);
 
@@ -73,7 +74,7 @@ const legendItemsLicenseRemarks = ref<any[]>([]);
 const testColor = ref('#ffffff');
 const legendItemsPolicyStates = ref<any[]>([]);
 const legendItemsLicenseFamily = ref<any[]>([]);
-const alternateRender = ref(appStore.alternateRender);
+const alternateRender = ref(useAppStore().alternateRender);
 
 onMounted(async () => {
   testColor.value = getColor('--v-theme-licenceChartIcon');

--- a/frontend/libs/portal/components/projects/projectsVersions/sbom-quality/TabLicenseRemarks.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/sbom-quality/TabLicenseRemarks.vue
@@ -6,6 +6,7 @@ import ProjectService, {RemarkTypes} from '@disclosure-portal/services/projects'
 import VersionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {downloadFile} from '@disclosure-portal/utils/download';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import useViewTools, {getIconColorOfLevel, getIconOfLevel, getStrWithMaxLength} from '@disclosure-portal/utils/View';
@@ -18,6 +19,7 @@ import {useI18n} from 'vue-i18n';
 const {t} = useI18n();
 const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const viewTools = useViewTools();
 const {getTextOfLevel, getTextOfType} = useView();
 
@@ -122,8 +124,8 @@ watch(menu3, () => (menu.value = menu2.value = false));
 const searchFieldInput = ref<string>('');
 
 const projectModel = computed(() => projectStore.currentProject!);
-const version = computed(() => appStore.getCurrentVersion);
-const spdx = computed(() => appStore.selectedSpdx);
+const version = computed(() => sbomStore.getCurrentVersion);
+const spdx = computed(() => sbomStore.selectedSpdx);
 
 const possibleTypes = computed(() => {
   if (!selectedLicenseRemarks.value.obligations) {

--- a/frontend/libs/portal/components/projects/projectsVersions/sbom-quality/TabScanRemarks.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/sbom-quality/TabScanRemarks.vue
@@ -238,8 +238,8 @@ import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
 import {ScanRemark, ScanRemarkLevel} from '@disclosure-portal/model/Quality';
 import ProjectService, {RemarkTypes} from '@disclosure-portal/services/projects';
 import VersionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {downloadFile} from '@disclosure-portal/utils/download';
 import {
   getIconColorScanRemarkLevel,
@@ -254,8 +254,8 @@ import {computed, onMounted, ref, watch} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRoute} from 'vue-router';
 
-const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const {t} = useI18n();
 
 const search = ref('');
@@ -380,8 +380,8 @@ onMounted(async () => {
 });
 
 const projectModel = computed(() => projectStore.currentProject!);
-const version = computed(() => appStore.getCurrentVersion);
-const spdx = computed(() => appStore.selectedSpdx);
+const version = computed(() => sbomStore.getCurrentVersion);
+const spdx = computed(() => sbomStore.selectedSpdx);
 
 const filteredList = computed(() => {
   return tableItems.value.filter((item: ScanRemark) => {

--- a/frontend/libs/portal/stores/app.ts
+++ b/frontend/libs/portal/stores/app.ts
@@ -4,13 +4,8 @@
 
 import INavItem, {INavItemGroup} from '@disclosure-portal/model/INavItem';
 import ITile from '@disclosure-portal/model/ITile';
-import {ProjectModel} from '@disclosure-portal/model/Project';
-import {NameKeyIdentifier, VersionSboms, VersionSbomsFlat} from '@disclosure-portal/model/ProjectsResponse';
-import {SpdxFile, VersionSlim} from '@disclosure-portal/model/VersionDetails';
 import {GetDashboardCounts} from '@disclosure-portal/services/admin';
-import ProjectService from '@disclosure-portal/services/projects';
 import sessionService from '@disclosure-portal/services/session';
-import versionService from '@disclosure-portal/services/version';
 import {LabelsTools} from '@disclosure-portal/utils/Labels';
 import {useStorage} from '@vueuse/core';
 import {defineStore} from 'pinia';
@@ -36,13 +31,6 @@ export const useAppStore = defineStore('app', () => {
   const state = reactive({
     appLanguage: resolveInitialAppLanguage(),
     LabelsTools: new LabelsTools(),
-    currentProject: {} as ProjectModel,
-    currentVersion: {} as VersionSlim,
-    channelSpdxs: [] as SpdxFile[],
-    selectedSpdx: {} as SpdxFile,
-    allSBOMSFlat: [] as VersionSbomsFlat[],
-    allSBOMS: [] as VersionSboms[],
-    allVersions: [] as NameKeyIdentifier[],
     tiles: [] as ITile[],
     alternateRender: false,
     navItemGroup: {
@@ -154,61 +142,8 @@ export const useAppStore = defineStore('app', () => {
     setLanguage(state.appLanguage === 'en' ? 'de' : 'en');
   };
 
-  const resetCurrentProject = () => {
-    state.currentProject = {} as ProjectModel;
-  };
-
-  const fetchCurrentProject = async (id: string) => {
-    state.currentProject = await ProjectService.get(id);
-  };
-
-  const refetchCurrentProject = async () => {
-    if (typeof state.currentProject._key === 'undefined') {
-      return;
-    }
-    await fetchCurrentProject(state.currentProject?._key);
-  };
-
-  const resetCurrentVersion = () => {
-    if (!state.currentVersion) {
-      return;
-    }
-    state.currentVersion = state.currentProject.versions[state.currentVersion._key];
-  };
-
-  const setCurrentVersion = (version: VersionSlim) => {
-    state.currentVersion = version;
-  };
-
-  const setSelectedSpdx = (spdx: SpdxFile) => {
-    state.selectedSpdx = spdx;
-  };
-
-  const setChannelSpdxs = (spdxs: SpdxFile[]) => {
-    state.channelSpdxs = spdxs;
-  };
-
-  const fetchAllSBOMsFlat = async () => {
-    const data = await ProjectService.getAllSbomsFlat(state.currentProject._key);
-    state.allSBOMSFlat = data.items;
-    state.allVersions = data.versions;
-  };
-
-  const fetchAllSBOMs = async () => {
-    state.allSBOMS = await ProjectService.getAllSboms(state.currentProject._key);
-  };
-
-  const fetchSBOMHistory = async () => {
-    const spdxFileHistory = (await versionService.getSbomHistory(state.currentProject._key, state.currentVersion._key))
-      .data;
-    if (spdxFileHistory[0]) {
-      spdxFileHistory[0].isRecent = true;
-    }
-    setChannelSpdxs(spdxFileHistory);
-  };
-
-  const setDummyDesignMode = () => {
-    state.dummyDesignMode = state.currentProject.isDummy;
+  const setDummyDesignMode = (isDummy: boolean) => {
+    state.dummyDesignMode = isDummy;
   };
 
   const unsetDummyDesignMode = () => {
@@ -238,12 +173,6 @@ export const useAppStore = defineStore('app', () => {
   // Getters
   const getLabelsTools = computed(() => state.LabelsTools);
   const getAppLanguage = computed(() => state.appLanguage);
-  const getCurrentProject = computed(() => state.currentProject);
-  const getCurrentVersion = computed(() => state.currentVersion);
-  const getChannelSpdxs = computed(() => state.channelSpdxs);
-  const getSelectedSpdx = computed(() => state.selectedSpdx);
-  const getAllSBOMsFlat = computed(() => state.allSBOMSFlat);
-  const getAllSBOMs = computed(() => state.allSBOMS);
 
   return {
     // State
@@ -260,16 +189,6 @@ export const useAppStore = defineStore('app', () => {
     startTokenRefresher,
     toggleLanguage,
     setLanguage,
-    resetCurrentProject,
-    fetchCurrentProject,
-    refetchCurrentProject,
-    resetCurrentVersion,
-    setCurrentVersion,
-    setSelectedSpdx,
-    setChannelSpdxs,
-    fetchAllSBOMsFlat,
-    fetchAllSBOMs,
-    fetchSBOMHistory,
     setDummyDesignMode,
     unsetDummyDesignMode,
     setShouldReloadApprovals,
@@ -277,11 +196,5 @@ export const useAppStore = defineStore('app', () => {
     // Getters
     getLabelsTools,
     getAppLanguage,
-    getCurrentProject,
-    getCurrentVersion,
-    getChannelSpdxs,
-    getSelectedSpdx,
-    getAllSBOMsFlat,
-    getAllSBOMs,
   };
 });

--- a/frontend/libs/portal/stores/project.store.ts
+++ b/frontend/libs/portal/stores/project.store.ts
@@ -8,7 +8,7 @@ import ProjectPostRequest from '@disclosure-portal/model/ProjectPostRequest';
 import {ProjectSlim} from '@disclosure-portal/model/ProjectsResponse';
 import {WizardProjectPostRequest} from '@disclosure-portal/model/Wizard';
 import {default as projectService} from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {SearchOptions} from '@disclosure-portal/utils/Table';
 import useSnackbar from '@shared/composables/useSnackbar';
 import {defineStore} from 'pinia';
@@ -24,8 +24,6 @@ export enum ProjectStatusType {
 export const useProjectStore = defineStore('project', () => {
   const {info} = useSnackbar();
   const {t} = useI18n();
-  // TODO backwards-compatibility remove when appStore.currentProject is removed
-  const appStore = useAppStore();
 
   const state = reactive({
     projects: [] as ProjectSlim[],
@@ -45,9 +43,7 @@ export const useProjectStore = defineStore('project', () => {
 
   const resetCurrentProject = () => {
     state.currentProject = null;
-    appStore.selectedSpdx = {};
-    appStore.currentVersion = {};
-    appStore.resetCurrentProject();
+    useSbomStore().reset();
   };
 
   watch(
@@ -93,7 +89,6 @@ export const useProjectStore = defineStore('project', () => {
 
       const project = createProjectModel(await projectService.get(projectKey));
 
-      appStore.currentProject = project;
       state.currentProject = project;
       if (project.isGroup) {
         state.currentProject.projectChildren = await projectService.getChildren(projectKey);

--- a/frontend/libs/portal/stores/sbom.store.ts
+++ b/frontend/libs/portal/stores/sbom.store.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 Mercedes-Benz Group AG and Mercedes-Benz AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {NameKeyIdentifier, VersionSboms, VersionSbomsFlat} from '@disclosure-portal/model/ProjectsResponse';
+import {SpdxFile, VersionSlim} from '@disclosure-portal/model/VersionDetails';
+import ProjectService from '@disclosure-portal/services/projects';
+import versionService from '@disclosure-portal/services/version';
+import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {defineStore} from 'pinia';
+import {computed, reactive, toRefs} from 'vue';
+
+export const useSbomStore = defineStore('sbom', () => {
+  const projectStore = useProjectStore();
+
+  const state = reactive({
+    currentVersion: {} as VersionSlim,
+    channelSpdxs: [] as SpdxFile[],
+    selectedSpdx: {} as SpdxFile,
+    allSBOMSFlat: [] as VersionSbomsFlat[],
+    allSBOMS: [] as VersionSboms[],
+    allVersions: [] as NameKeyIdentifier[],
+  });
+
+  // Actions
+  const setCurrentVersion = (version: VersionSlim) => {
+    state.currentVersion = version;
+  };
+
+  const resetCurrentVersion = () => {
+    if (!state.currentVersion?._key) return;
+    const project = projectStore.currentProject;
+    if (!project) return;
+    state.currentVersion = project.versions[state.currentVersion._key];
+  };
+
+  const setSelectedSpdx = (spdx: SpdxFile) => {
+    state.selectedSpdx = spdx;
+  };
+
+  const setChannelSpdxs = (spdxs: SpdxFile[]) => {
+    state.channelSpdxs = spdxs;
+  };
+
+  const fetchAllSBOMsFlat = async () => {
+    const projectKey = projectStore.currentProject?._key;
+    if (!projectKey) return;
+    const data = await ProjectService.getAllSbomsFlat(projectKey);
+    state.allSBOMSFlat = data.items;
+    state.allVersions = data.versions;
+  };
+
+  const fetchAllSBOMs = async () => {
+    const projectKey = projectStore.currentProject?._key;
+    if (!projectKey) return;
+    state.allSBOMS = await ProjectService.getAllSboms(projectKey);
+  };
+
+  const fetchSBOMHistory = async () => {
+    const projectKey = projectStore.currentProject?._key;
+    if (!projectKey || !state.currentVersion._key) return;
+    const spdxFileHistory = (await versionService.getSbomHistory(projectKey, state.currentVersion._key)).data;
+    if (spdxFileHistory[0]) {
+      spdxFileHistory[0].isRecent = true;
+    }
+    setChannelSpdxs(spdxFileHistory);
+  };
+
+  const reset = () => {
+    state.currentVersion = {} as VersionSlim;
+    state.channelSpdxs = [];
+    state.selectedSpdx = {} as SpdxFile;
+    state.allSBOMSFlat = [];
+    state.allSBOMS = [];
+    state.allVersions = [];
+  };
+
+  // Getters
+  const getCurrentVersion = computed(() => state.currentVersion);
+  const getChannelSpdxs = computed(() => state.channelSpdxs);
+  const getSelectedSpdx = computed(() => state.selectedSpdx);
+  const getAllSBOMsFlat = computed(() => state.allSBOMSFlat);
+  const getAllSBOMs = computed(() => state.allSBOMS);
+
+  return {
+    ...toRefs(state),
+
+    // Actions
+    setCurrentVersion,
+    resetCurrentVersion,
+    setSelectedSpdx,
+    setChannelSpdxs,
+    fetchAllSBOMsFlat,
+    fetchAllSBOMs,
+    fetchSBOMHistory,
+    reset,
+
+    // Getters
+    getCurrentVersion,
+    getChannelSpdxs,
+    getSelectedSpdx,
+    getAllSBOMsFlat,
+    getAllSBOMs,
+  };
+});
+

--- a/frontend/libs/portal/views/projects/ProjectsDetail.vue
+++ b/frontend/libs/portal/views/projects/ProjectsDetail.vue
@@ -99,7 +99,7 @@ const reload = async () => {
 
 const initPage = async () => {
   await nextTick();
-  appStore.setDummyDesignMode();
+  appStore.setDummyDesignMode(currentProject.value?.isDummy ?? false);
   initBreadcrumbs();
 };
 

--- a/frontend/libs/portal/views/projects/ProjectsVersions.vue
+++ b/frontend/libs/portal/views/projects/ProjectsVersions.vue
@@ -261,7 +261,7 @@ watch(
 );
 
 watch(
-  [spdxFileHistory, spdxKey, versionKey, projectId],
+  [spdxKey, versionKey, projectId],
   async () => {
     await reload();
   },

--- a/frontend/libs/portal/views/projects/ProjectsVersions.vue
+++ b/frontend/libs/portal/views/projects/ProjectsVersions.vue
@@ -9,6 +9,7 @@ import versionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
 import {useIdleStore} from '@disclosure-portal/stores/idle.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {getStrWithMaxLength} from '@disclosure-portal/utils/View';
 import useSnackbar from '@shared/composables/useSnackbar';
@@ -24,13 +25,14 @@ const router = useRouter();
 const route = useRoute();
 const appStore = useAppStore();
 const projectStore = useProjectStore();
+const sbomStore = useSbomStore();
 const {info: snack} = useSnackbar();
 const idle = useIdleStore();
 const {dashboardCrumbs, projectsCrumb, ...breadcrumbs} = useBreadcrumbsStore();
 const {useReactiveTitle} = usePageTitle();
 const {currentProject} = storeToRefs(projectStore);
 
-const {selectedSpdx, currentVersion, channelSpdxs} = storeToRefs(appStore);
+const {selectedSpdx, currentVersion, channelSpdxs} = storeToRefs(sbomStore);
 
 const reviewDia = ref(null);
 const confirmConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDialogConfig);
@@ -105,23 +107,23 @@ const reload = async () => {
   }
   if (!versionDetails.value || versionDetails.value._key !== versionKey.value) {
     const vd = currentProject.value?.versions[versionKey.value] ?? '';
-    appStore.setCurrentVersion(vd);
+    sbomStore.setCurrentVersion(vd);
     const spdxFileHistory = (await versionService.getSbomHistory(projectId.value, versionKey.value)).data;
     if (spdxFileHistory[0]) {
       spdxFileHistory[0].isRecent = true;
     }
-    appStore.setChannelSpdxs(spdxFileHistory);
+    sbomStore.setChannelSpdxs(spdxFileHistory);
   }
   let selectedByRoute = false;
   if (spdxKey.value) {
     const sel = spdxFileHistory.value.find((spdx) => spdx._key === spdxKey.value);
     if (sel) {
-      appStore.setSelectedSpdx(sel);
+      sbomStore.setSelectedSpdx(sel);
       selectedByRoute = true;
     }
   }
   if (!selectedByRoute) {
-    appStore.setSelectedSpdx(spdxFileHistory.value[0] || null);
+    sbomStore.setSelectedSpdx(spdxFileHistory.value[0] || null);
     await resetUrl();
   }
   if (route.name === 'VersionSubTap') {
@@ -132,7 +134,7 @@ const reload = async () => {
 
 const initPage = async () => {
   await nextTick();
-  appStore.setDummyDesignMode();
+  appStore.setDummyDesignMode(currentProject.value?.isDummy ?? false);
   initBreadcrumbs();
 };
 
@@ -300,8 +302,8 @@ watch(
 );
 
 onUnmounted(() => {
-  appStore.setCurrentVersion({} as VersionSlim);
-  appStore.setSelectedSpdx({} as SpdxFile);
+  sbomStore.setCurrentVersion({} as VersionSlim);
+  sbomStore.setSelectedSpdx({} as SpdxFile);
   appStore.unsetDummyDesignMode();
 });
 </script>

--- a/frontend/libs/shared/components/disco/DSpdxTagDialog.vue
+++ b/frontend/libs/shared/components/disco/DSpdxTagDialog.vue
@@ -3,8 +3,8 @@ import {Tags} from '@disclosure-portal/constants/ruleValidations';
 import {VersionSlim} from '@disclosure-portal/model/VersionDetails';
 import projectService from '@disclosure-portal/services/projects';
 import versionService from '@disclosure-portal/services/version';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
+import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import useRules from '@disclosure-portal/utils/Rules';
 import DCActionButton from '@shared/components/disco/DCActionButton.vue';
 import DCloseButton from '@shared/components/disco/DCloseButton.vue';
@@ -43,8 +43,8 @@ export default defineComponent({
     const {t} = useI18n();
     const isVisible = ref(false);
     const tag = ref('');
-    const appStore = useAppStore();
     const projectStore = useProjectStore();
+    const sbomStore = useSbomStore();
     const dialog = ref<VForm | null>(null);
     const {info: snack} = useSnackbar();
     const showDialog = () => {
@@ -79,10 +79,10 @@ export default defineComponent({
             if (spdxFileHistory[0]) {
               spdxFileHistory[0].isRecent = true;
             }
-            appStore.setChannelSpdxs(spdxFileHistory);
-            await appStore.fetchAllSBOMs();
+            sbomStore.setChannelSpdxs(spdxFileHistory);
+            await sbomStore.fetchAllSBOMs();
           } else {
-            await appStore.fetchAllSBOMsFlat();
+            await sbomStore.fetchAllSBOMsFlat();
           }
           dialog.value?.reset();
           isVisible.value = false;
@@ -90,7 +90,7 @@ export default defineComponent({
       });
     };
     const projectModel = computed(() => projectStore.currentProject!);
-    const versionDetails = computed((): VersionSlim => appStore.getCurrentVersion);
+    const versionDetails = computed((): VersionSlim => sbomStore.getCurrentVersion);
 
     const activeRules = ref({
       tag: useRules().minMax(t('COL_SBOM_TAG'), Tags.TAG_MIN_LENGTH, Tags.TAG_MAX_LENGTH, false),


### PR DESCRIPTION
- This is the first part of refactoring sbom logic in frontend
- Remove project and sbom logic from `app.ts`
- Move sbom logic 1:1 to own sbom store for backwards compability

1. Move logic to sbom store ✅
2. Unify the logic of all sbom components to use sbom store instead of using props and expand the sbom store logic to be smarter -- next PR

### Please take time to review, there might be things that I've missed

