### PR TITLE
ActionSlider for License Table

### DIFF
--- a/frontend/libs/portal/views/licenses/Licenses.vue
+++ b/frontend/libs/portal/views/licenses/Licenses.vue
@@ -20,6 +20,7 @@ import {SearchOptions} from '@disclosure-portal/utils/Table';
 import useViewTools, {getIconColorOfLevel, getIconOfLevel, openUrl} from '@disclosure-portal/utils/View';
 import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
+import {useTableActionSlider} from '@shared/composables/useTableActionSlider';
 import {useBreadcrumbsStore} from '@shared/stores/breadcrumbs.store';
 import {useHeaderSettingsStore} from '@shared/stores/headerSettings.store';
 import {DataTableHeader, DataTableHeaderFilterItems, DataTableItem, SortItem} from '@shared/types/table';
@@ -81,73 +82,73 @@ const abort = ref<AbortController | null>(null);
 const possibleIsLicenseChart = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleCharts)
-        .map(([k, count]) => ({
-          text: k === 'true' ? t('TABLE_LICENSE_CHART_STATUS_IS') : t('TABLE_LICENSE_CHART_STATUS_IS_NOT'),
-          value: k,
-          chip: String(count),
-        }))
-        .sort()
+      .map(([k, count]) => ({
+        text: k === 'true' ? t('TABLE_LICENSE_CHART_STATUS_IS') : t('TABLE_LICENSE_CHART_STATUS_IS_NOT'),
+        value: k,
+        chip: String(count),
+      }))
+      .sort()
     : [],
 );
 
 const possibleSources = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleSources).map(([k, count]) => ({
-        text: k,
-        value: k,
-        chip: String(count),
-      }))
+      text: k,
+      value: k,
+      chip: String(count),
+    }))
     : [],
 );
 
 const possibleFamilies = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleFamilies)
-        .sort((a, b) => compareFamily(a[0], b[0]))
-        .map(([k, count]) => ({
-          text: getI18NTextOfPrefixKey('LIC_FAMILY_', k),
-          value: k.length === 0 ? 'not declared' : k,
-          chip: String(count),
-        }))
-    : [],
-);
-
-const possibleApproval = computed((): DataTableHeaderFilterItems[] =>
-  metaData.value
-    ? Object.entries(metaData.value.possibleApproval)
-        .sort(
-          ([keyA], [keyB]) => getLicenseApprovalTypeKeys().indexOf(keyA) - getLicenseApprovalTypeKeys().indexOf(keyB),
-        )
-        .map(([k, count]) => ({
-          text: getI18NTextOfPrefixKey('LT_APP_', k),
-          value: k.length === 0 ? 'not set' : k,
-          chip: String(count),
-        }))
-    : [],
-);
-
-const possibleType = computed((): DataTableHeaderFilterItems[] =>
-  metaData.value
-    ? Object.entries(metaData.value.possibleType).map(([k, count]) => ({
-        text: getI18NTextOfPrefixKey('LT_', k),
+      .sort((a, b) => compareFamily(a[0], b[0]))
+      .map(([k, count]) => ({
+        text: getI18NTextOfPrefixKey('LIC_FAMILY_', k),
         value: k.length === 0 ? 'not declared' : k,
         chip: String(count),
       }))
     : [],
 );
 
+const possibleApproval = computed((): DataTableHeaderFilterItems[] =>
+  metaData.value
+    ? Object.entries(metaData.value.possibleApproval)
+      .sort(
+        ([keyA], [keyB]) => getLicenseApprovalTypeKeys().indexOf(keyA) - getLicenseApprovalTypeKeys().indexOf(keyB),
+      )
+      .map(([k, count]) => ({
+        text: getI18NTextOfPrefixKey('LT_APP_', k),
+        value: k.length === 0 ? 'not set' : k,
+        chip: String(count),
+      }))
+    : [],
+);
+
+const possibleType = computed((): DataTableHeaderFilterItems[] =>
+  metaData.value
+    ? Object.entries(metaData.value.possibleType).map(([k, count]) => ({
+      text: getI18NTextOfPrefixKey('LT_', k),
+      value: k.length === 0 ? 'not declared' : k,
+      chip: String(count),
+    }))
+    : [],
+);
+
 const possibleClassifications = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? metaData.value.possibleClassifications.map(({classification, count}: ClassificationWithCount) => {
-        const value = viewTools.getNameForLanguage(classification) ? classification.name : '';
-        return {
-          text: viewTools.getNameForLanguage(classification) || t('NO_CLASSIFICATIONS'),
-          value: value,
-          icon: getIconOfLevel(getWarnLevel(value).toUpperCase()),
-          iconColor: getIconColorOfLevel(getWarnLevel(value)),
-          chip: String(count),
-        };
-      })
+      const value = viewTools.getNameForLanguage(classification) ? classification.name : '';
+      return {
+        text: viewTools.getNameForLanguage(classification) || t('NO_CLASSIFICATIONS'),
+        value: value,
+        icon: getIconOfLevel(getWarnLevel(value).toUpperCase()),
+        iconColor: getIconColorOfLevel(getWarnLevel(value)),
+        chip: String(count),
+      };
+    })
     : [],
 );
 
@@ -303,18 +304,27 @@ const getActionButtons = (item: LicenseSlim): TableActionButtonsProps['buttons']
       show: canCreate,
     },
     {
-      icon: 'mdi-delete',
-      hint: t('TT_delete_license'),
-      event: 'delete',
-      show: canDelete,
-    },
-    {
       icon: 'mdi-bank-outline',
       hint: t('CONFIGURE_POLICIES_FOR_LICENSE_TOOLTIP'),
       event: 'configure',
       show: canConfigurePolicies,
     },
+    {
+      icon: 'mdi-delete',
+      hint: t('TT_delete_license'),
+      event: 'delete',
+      show: canDelete,
+    },
   ];
+};
+
+const {baseWidth} = useTableActionSlider();
+
+const expandedWidth = ref<number>(baseWidth.value);
+
+const headerExpands = (value: number) => {
+  expandedWidth.value = value;
+  headerSettingsStore.setupStore(gridName, headers.value);
 };
 
 const allowActions = computed(() => RightsUtils.hasLicenseAccess() || RightsUtils.hasPolicyAccess());
@@ -322,15 +332,13 @@ const allowActions = computed(() => RightsUtils.hasLicenseAccess() || RightsUtil
 const headers = computed((): DataTableHeader[] => [
   ...(allowActions.value
     ? [
-        {
-          title: 'COL_ACTIONS',
-          align: 'center',
-          width: 120,
-          maxWidth: 130,
-          value: 'actions',
-          sortable: false,
-        } as DataTableHeader,
-      ]
+      {
+        title: 'COL_ACTIONS',
+        align: 'center',
+        width: expandedWidth.value,
+        value: 'actions',
+      } as DataTableHeader,
+    ]
     : []),
   {
     title: 'COL_LICENSE_CHART_STATUS',
@@ -374,7 +382,6 @@ const headers = computed((): DataTableHeader[] => [
     align: 'start',
     value: 'aliases',
     width: 220,
-    sortable: false,
   },
   {
     title: 'COL_APPROVAL_STATUS',
@@ -661,7 +668,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <TableLayout data-testid="licenses">
+  <TableLayout data-testid="licenses" @mouseleave="headerExpands(baseWidth)">
     <template #description>
       <div class="d-flex flex-row align-center ga-3">
         <h1 class="text-h5">{{ t('Licenses') }}</h1>
@@ -732,7 +739,7 @@ onMounted(async () => {
         return-object></v-select>
     </template>
     <template #table>
-      <div ref="dataGridLicenses" class="table-wrapper fill-height">
+      <div ref="dataGridLicenses" class="table-wrapper fill-height action-slider-table">
         <v-data-table-server
           :headers="filteredHeaders"
           fixed-header
@@ -749,69 +756,86 @@ onMounted(async () => {
           v-model:options="options">
           <!-- Settings column header slot -->
           <template v-if="allowActions" #[`header.actions`]="{column}">
-            <HeaderSettings :grid-name="gridName" :column="column" />
-            <span class="ml-6">{{ column.title }}</span>
+            <GridFilterHeader :column="column">
+              <template #settings>
+                <HeaderSettings :grid-name="gridName" :column="column" />
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.meta.isLicenseChart`]="{column, getSortIcon, toggleSort}">
-            <HeaderSettings v-if="!allowActions" :grid-name="gridName" :column="column" />
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterIsLicenseChart"
-              :column="column"
-              :label="t('LICENSE_CHART_STATUS')"
-              :allItems="possibleIsLicenseChart">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #settings>
+                <HeaderSettings v-if="!allowActions" :grid-name="gridName" :column="column" />
+              </template>
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterIsLicenseChart"
+                  :column="column"
+                  :label="t('LICENSE_CHART_STATUS')"
+                  :allItems="possibleIsLicenseChart">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.source`]="{column, getSortIcon, toggleSort}">
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterSource"
-              :column="column"
-              :label="t('SOURCE')"
-              :allItems="possibleSources">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterSource"
+                  :column="column"
+                  :label="t('SOURCE')"
+                  :allItems="possibleSources">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.meta.family`]="{column, getSortIcon, toggleSort}">
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterFamily"
-              :column="column"
-              :label="t('LICENSE_FAMILY')"
-              :allItems="possibleFamilies">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterFamily"
+                  :column="column"
+                  :label="t('LICENSE_FAMILY')"
+                  :allItems="possibleFamilies">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.meta.approvalState`]="{column, getSortIcon, toggleSort}">
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterApproval"
-              :column="column"
-              :label="t('APPROVAL_STATUS')"
-              :allItems="possibleApproval">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterApproval"
+                  :column="column"
+                  :label="t('APPROVAL_STATUS')"
+                  :allItems="possibleApproval">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.meta.licenseType`]="{column, getSortIcon, toggleSort}">
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterType"
-              :column="column"
-              :label="t('LICENSE_TYPE')"
-              :allItems="possibleType">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterType"
+                  :column="column"
+                  :label="t('LICENSE_TYPE')"
+                  :allItems="possibleType">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`header.meta.classifications`]="{column, getSortIcon, toggleSort}">
-            <span class="mr-1">{{ column.title }}</span>
-            <GridHeaderFilterIcon
-              v-model="selectedFilterClassification"
-              :column="column"
-              :label="t('CLASSIFICATION')"
-              :allItems="possibleClassifications">
-            </GridHeaderFilterIcon>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterClassification"
+                  :column="column"
+                  :label="t('CLASSIFICATION')"
+                  :allItems="possibleClassifications">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
           <template #[`item.meta.classifications`]="{item}">
             <span @click.stop="openClassifications(item.meta.classifications, item.name, item.licenseId)">
@@ -819,7 +843,7 @@ onMounted(async () => {
               <v-icon
                 :class="item.meta.prevalentClassificationLevel.toUpperCase() === 'WARNING' ? 'mr-1' : 'mr-2'"
                 :color="getIconColorOfLevel(item.meta.prevalentClassificationLevel)"
-                >{{ getIconOfLevel(item.meta.prevalentClassificationLevel) }}
+              >{{ getIconOfLevel(item.meta.prevalentClassificationLevel) }}
               </v-icon>
               <Tooltip location="bottom">
                 {{ t('TT_OPEN_CLASSIFICATIONS', {license: item.name}) }}
@@ -852,12 +876,14 @@ onMounted(async () => {
           </template>
           <template v-if="allowActions" #[`item.actions`]="{item}">
             <TableActionButtons
-              variant="compact"
+              variant="slider"
               :buttons="getActionButtons(item)"
               @edit="editLicense(item)"
               @duplicate="duplicateLicense(item)"
               @delete="showDeletionConfirmationDialog(item)"
-              @configure="configurePoliciesForLicense(item)" />
+              @configure="configurePoliciesForLicense(item)"
+              @slideOut="headerExpands($event as number)"
+              @slideIn="headerExpands($event as number)" />
           </template>
           <template #[`item.aliases`]="{item}">
             <span v-if="Array.isArray(item.aliases) && item.aliases.length > 0">

--- a/frontend/libs/shared/components/TableActionButtons.vue
+++ b/frontend/libs/shared/components/TableActionButtons.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {useTableActionSlider} from '@shared/composables/useTableActionSlider';
 import {computed} from 'vue';
+import {useI18n} from 'vue-i18n';
 
 interface Button {
   icon: string;
@@ -15,14 +16,18 @@ export interface TableActionButtonsProps {
   buttons: Button[];
   variant?: 'normal' | 'minimal' | 'compact' | 'slider';
 }
+
 const props = withDefaults(defineProps<TableActionButtonsProps>(), {
   variant: 'normal',
 });
+
 const emit = defineEmits<{
   slideOut: [value: number];
   slideIn: [value: number];
   [key: string]: [value?: number];
 }>();
+
+const {t} = useI18n();
 
 const shownButtons = computed(() => props.buttons.filter((button) => button.show ?? true));
 const outsideButtons = computed(() => shownButtons.value.slice(0, 1));
@@ -52,7 +57,7 @@ if (props.variant === 'slider') {
             :hint="button.hint"
             :color="button.color"
             :disabled="button.disabled"
-            @clicked="emit(button.event)"></DIconButton>
+            @clicked="emit(button.event)" />
         </div>
       </ExtraMenu>
     </template>
@@ -66,40 +71,45 @@ if (props.variant === 'slider') {
           :hint="button.hint"
           :color="button.color"
           :disabled="button.disabled"
-          @clicked="emit(button.event)"></DIconButton>
+          @clicked="emit(button.event)" />
       </div>
     </template>
 
     <!-- Normal Variant: All buttons displayed -->
     <template v-else-if="variant === 'slider'">
-      <div class="flex justify-start pl-8">
+      <div
+        class="flex justify-start pl-8 pr-5"
+        @click.stop
+        @mouseenter="stopSlideInTimerAndSlideOut"
+        @mouseleave="startSlideInTimer">
         <v-btn
+          v-if="shownButtons.length >= 2"
           plain
           size="small"
           variant="text"
           icon
           color="primary"
           class="size-10"
-          @click.stop
-          @mouseenter="stopSlideInTimerAndSlideOut"
-          @mouseleave="startSlideInTimer">
+          @click.stop>
           <v-icon>mdi-dots-horizontal</v-icon>
-          <Tooltip location="bottom" text="Actions"></Tooltip>
+          <Tooltip location="bottom" :text="t('OPEN_ACTIONS')" />
         </v-btn>
-        <div
-          v-for="button in buttons"
-          :key="button.icon"
-          class="size-10"
-          @mouseenter="stopSlideInTimerAndSlideOut"
-          @mouseleave="startSlideInTimer">
-          <DIconButton
-            v-if="button.show ?? true"
-            :icon="button.icon"
-            :hint="button.hint"
-            :color="button.color"
-            :disabled="button.disabled"
-            @clicked="emit(button.event)"></DIconButton>
-        </div>
+        <template v-for="button in buttons" :key="button.icon">
+          <div
+            v-if="button?.show ?? true"
+            class="d-inline size-10"
+            @click.stop="!button?.disabled ? emit(button.event) : null">
+            <v-btn
+              plain
+              size="small"
+              variant="text"
+              density="default"
+              :icon="button.icon"
+              :color="button.color || 'primary'"
+              :disabled="Boolean(button?.disabled) || false" />
+            <Tooltip v-if="button.hint && !button?.disabled" location="bottom" :text="button.hint" />
+          </div>
+        </template>
       </div>
     </template>
 
@@ -123,7 +133,7 @@ if (props.variant === 'slider') {
           :hint="button.hint"
           :color="button.color"
           :disabled="button.disabled"
-          @clicked="emit(button.event)"></DIconButton>
+          @clicked="emit(button.event)" />
       </div>
 
       <div v-if="remainingButtons.length > 0" class="size-10">
@@ -134,7 +144,7 @@ if (props.variant === 'slider') {
               :hint="button.hint"
               :color="button.color"
               :disabled="button.disabled"
-              @clicked="emit(button.event)"></DIconButton>
+              @clicked="emit(button.event)" />
           </div>
         </ExtraMenu>
       </div>

--- a/frontend/libs/shared/composables/useTableActionSlider.ts
+++ b/frontend/libs/shared/composables/useTableActionSlider.ts
@@ -7,6 +7,9 @@ export const useTableActionSlider = () => {
   const tableActionSliderStore = useTableActionSliderStore();
   const {slideInTimeout} = storeToRefs(tableActionSliderStore);
 
+  const buttonWidth = 40;
+  const spaceAfter = 20;
+
   const baseWidth = ref<number>(100);
   const buttonsLength = ref<number>(1);
   const sliderWidth = ref<number>(baseWidth.value);
@@ -38,19 +41,21 @@ export const useTableActionSlider = () => {
     }
   };
 
-  const expandedMaxWidth = computed(() => buttonsLength.value * 40 + baseWidth.value);
+  const expandedMaxWidth = computed(() => buttonsLength.value * buttonWidth + baseWidth.value + spaceAfter);
 
   const startSlideInTimer = () => {
-    slideInTimer.value = 300;
+    if (buttonsLength.value >= 2) {
+      slideInTimer.value = 300;
 
-    if (slideInTimeout.value) {
-      clearTimeout(slideInTimeout.value);
-      slideInTimeout.value = null;
+      if (slideInTimeout.value) {
+        clearTimeout(slideInTimeout.value);
+        slideInTimeout.value = null;
+      }
+
+      slideInTimeout.value = setTimeout(() => {
+        slideInTimer.value = 0;
+      }, slideInTimer.value);
     }
-
-    slideInTimeout.value = setTimeout(() => {
-      slideInTimer.value = 0;
-    }, slideInTimer.value);
   };
 
   const slideOut = () => {
@@ -64,12 +69,14 @@ export const useTableActionSlider = () => {
   };
 
   const stopSlideInTimerAndSlideOut = () => {
-    if (slideInTimeout.value) {
-      clearTimeout(slideInTimeout.value);
-      slideInTimeout.value = null;
-    }
+    if (buttonsLength.value >= 2) {
+      if (slideInTimeout.value) {
+        clearTimeout(slideInTimeout.value);
+        slideInTimeout.value = null;
+      }
 
-    slideOut();
+      slideOut();
+    }
   };
 
   watch(slideInTimer, () => {

--- a/frontend/libs/shared/i18n/locales/de.json
+++ b/frontend/libs/shared/i18n/locales/de.json
@@ -2,5 +2,6 @@
   "Btn_clear_headers": "Ansicht zurücksetzen",
   "Btn_clear_filters": "Filter zurücksetzen",
   "FILTER_ON": "Filter auf",
-  "OTHERS": "andere"
+  "OTHERS": "andere",
+  "OPEN_ACTIONS": "Aktionen zeigen"
 }

--- a/frontend/libs/shared/i18n/locales/en.json
+++ b/frontend/libs/shared/i18n/locales/en.json
@@ -2,5 +2,6 @@
   "Btn_clear_headers": "Reset to default",
   "Btn_clear_filters": "Reset filter",
   "FILTER_ON": "Filter on",
-  "OTHERS": "other | others"
+  "OTHERS": "other | others",
+  "OPEN_ACTIONS": "Show Actions"
 }


### PR DESCRIPTION
## TableActionButtons

Added ability to have only one button.
Added more space (padding) in front and after the buttons.
Added the 'Stay open functionality' for cross rows mouse hover.
Added the ability to not show buttons in the slider.
Added 'Show actions' hint for button to shared i18n.

## License
Added GridFilterHeader to License-headers

## Refactoring
- Licences grid
- TableActionButtons
- useTableActionSlider