### PR TITLE
Refactorings for various grids

### DIFF
--- a/frontend/libs/portal/components/grids/GridAuditLog.vue
+++ b/frontend/libs/portal/components/grids/GridAuditLog.vue
@@ -5,8 +5,6 @@
 <script setup lang="ts">
 import {AuditLog} from '@disclosure-portal/model/VersionDetails';
 import {escapeHtml} from '@disclosure-portal/utils/Validation';
-import DDateCellWithTooltip from '@shared/components/disco/DDateCellWithTooltip.vue';
-import TableLayout from '@shared/layouts/TableLayout.vue';
 import {DataTableHeader, SortItem} from '@shared/types/table';
 import {computed, onMounted, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
@@ -25,6 +23,7 @@ const headers = computed<DataTableHeader[]>(() => [
   },
   {
     title: t('COL_TITLE'),
+    width: 200,
     align: 'start',
     value: 'message',
     sortable: true,

--- a/frontend/libs/portal/components/grids/GridChildren.vue
+++ b/frontend/libs/portal/components/grids/GridChildren.vue
@@ -3,8 +3,6 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <script setup lang="ts">
-import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
-import {Project} from '@disclosure-portal/model/Project';
 import {ProjectChildrenCombiDto, ProjectSlimDto} from '@disclosure-portal/model/ProjectsResponse';
 import {useDialogStore} from '@disclosure-portal/stores/dialog.store';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
@@ -16,19 +14,21 @@ import {TOOLTIP_OPEN_DELAY_IN_MS} from '@shared/utils/constant';
 import {computed, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRouter} from 'vue-router';
+import {storeToRefs} from 'pinia';
 
 const emit = defineEmits(['openSettings']);
 
 const {t} = useI18n();
 const router = useRouter();
-const projectStore = useProjectStore();
-const dialogStore = useDialogStore();
 const wizardStore = useWizardStore();
 
-const currentProject = computed((): Project => projectStore.currentProject!);
+const projectStore = useProjectStore();
+const {projectPossibleStatuses, currentProject} = storeToRefs(projectStore);
+
+const dialogStore = useDialogStore();
+const {isSettingsDialogOpen} = storeToRefs(dialogStore);
 
 const search = ref('');
-const statusFilterMenu = ref(false);
 const selectedFilterStatus = ref<string[]>([]);
 const addChildrenProjectDialog = ref();
 const errorDialog = ref();
@@ -44,19 +44,6 @@ const headers = computed<DataTableHeader[]>(() => {
     {title: t('COL_CREATED'), key: 'version.created', align: 'start', width: 160},
     {title: t('COL_UPDATED'), key: 'version.updated', align: 'start', width: 160},
   ];
-});
-
-const possibleStatus = computed(() => {
-  const list = currentProject.value?.projectChildren?.list;
-  if (!list?.length) return [];
-
-  return [...new Set(list.map((item: ProjectChildrenCombiDto) => item.project.status))].map(
-    (status: string) =>
-      ({
-        value: status,
-        text: status === 'deprecated' ? t('PROJECT_DEPRECATED') : status,
-      }) as IDefaultSelectItem,
-  );
 });
 
 const filterOnStatus = (item: ProjectChildrenCombiDto): boolean => {
@@ -76,12 +63,12 @@ const showCreateProjectDialog = async () => {
   if (!projectStore.areMandatoryProjectSettingsSet) {
     errorDialog.value?.open();
   } else {
-    await wizardStore.openWizard({parentProject: currentProject.value});
+    await wizardStore.openWizard({parentProject: currentProject.value!});
   }
 };
 
 const openSettingsDialog = () => {
-  dialogStore.isSettingsDialogOpen = true;
+  isSettingsDialogOpen.value = true;
 };
 
 const openProject = (item: ProjectSlimDto) => {
@@ -112,7 +99,7 @@ const showAddChildrenProjectDialog = () => {
   }
 };
 
-const customFilter = (value: string, query: string, item?: any) => {
+const customFilter = (_: string, query: string, item?: any) => {
   if (!query || !item) return true;
   const searchQuery = query.toLowerCase();
   const rawItem = item.raw as ProjectChildrenCombiDto;
@@ -175,7 +162,7 @@ const getStatusClass = computed(() => (status?: string) => {
         :custom-filter="customFilter"
         :headers="headers"
         :items="filteredList"
-        @click:row="(event: Event, dataItem: DataTableItem<ProjectChildrenCombiDto>) => openVersion(dataItem.item)"
+        @click:row="(_: Event, dataItem: DataTableItem<ProjectChildrenCombiDto>) => openVersion(dataItem.item)"
         :items-per-page="-1">
         <template v-slot:[`item.data-table-expand`]="{}"> x </template>
         <template v-slot:group-header="{item, toggleGroup, isGroupOpen}">
@@ -222,58 +209,17 @@ const getStatusClass = computed(() => (status?: string) => {
         <template v-slot:[`item.status`]="{item}">
           <DVersionStateWithTooltip v-if="item.version" :version="item.version" :isGroup="true" />
         </template>
-        <template v-slot:[`header.project.status`]="{column}">
-          <div class="v-data-table-header__content">
-            <span>{{ column.title }}</span>
-            <v-menu :close-on-content-click="false" v-model="statusFilterMenu">
-              <template v-slot:activator="{props}">
-                <DIconButton
-                  :parentProps="props"
-                  icon="mdi-filter-variant"
-                  :hint="t('TT_SHOW_FILTER')"
-                  :color="selectedFilterStatus.length > 0 ? 'primary' : 'default'" />
-              </template>
-              <div class="bg-background" style="width: 280px">
-                <v-row class="d-flex ma-1 mr-2 justify-end">
-                  <DIconButton icon="mdi-close" @clicked="statusFilterMenu = false" color="default" />
-                </v-row>
-                <v-select
-                  v-model="selectedFilterStatus"
-                  :items="possibleStatus"
-                  class="pa-2 mx-2 pb-4"
-                  :label="t('FILTER_BY_STATUS')"
-                  clearable
-                  multiple
-                  item-title="text"
-                  item-value="value"
-                  variant="outlined"
-                  density="compact"
-                  menu
-                  transition="scale-transition"
-                  persistent-clear
-                  :list-props="{class: 'striped-filter-dd py-0'}">
-                  <template v-slot:item="{item, props}">
-                    <v-list-item v-bind="props" class="px-2 py-0">
-                      <template v-slot:prepend="{isSelected}">
-                        <v-checkbox hide-details :model-value="isSelected" />
-                      </template>
-                      <template v-slot:title>
-                        <span :class="getStatusClass(item.raw.value)" class="pFilterEntry">{{ item.raw.text }}</span>
-                      </template>
-                    </v-list-item>
-                  </template>
-                  <template v-slot:selection="{item, index}">
-                    <div v-if="index === 0" class="d-flex align-center">
-                      <span class="pFilterEntry">{{ item.raw.text }}</span>
-                    </div>
-                    <span v-if="index === 1" class="pAdditionalFilter">
-                      +{{ selectedFilterStatus.length - 1 }} others
-                    </span>
-                  </template>
-                </v-select>
-              </div>
-            </v-menu>
-          </div>
+        <template v-slot:[`header.project.status`]="{column, getSortIcon, toggleSort}">
+          <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+            <template #filter>
+              <GridHeaderFilterIcon
+                v-model="selectedFilterStatus"
+                :column="column"
+                :label="t('COL_PROJECT_STATUS')"
+                :allItems="projectPossibleStatuses">
+              </GridHeaderFilterIcon>
+            </template>
+          </GridFilterHeader>
         </template>
         <template v-slot:[`item.project.status`]> </template>
         <template v-slot:[`item.version.updated`]="{item}">

--- a/frontend/libs/portal/components/grids/GridPolicyrules.vue
+++ b/frontend/libs/portal/components/grids/GridPolicyrules.vue
@@ -9,49 +9,49 @@ import projectService from '@disclosure-portal/services/projects';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import {getCssClassForReadonlyRow} from '@disclosure-portal/utils/Table';
 import {openUrlInNewTab} from '@disclosure-portal/utils/url';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
-import useSnackbar from '@shared/composables/useSnackbar';
-import TableLayout from '@shared/layouts/TableLayout.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import {useBreadcrumbsStore} from '@shared/stores/breadcrumbs.store';
 import {useClipboard} from '@shared/utils/clipboard';
 import dayjs from 'dayjs';
 import {computed, onMounted, ref, watch} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRouter} from 'vue-router';
+import {DataTableHeader} from '@shared/types/table';
 
 const {t} = useI18n();
 const projectStore = useProjectStore();
 const router = useRouter();
 const breadcrumbs = useBreadcrumbsStore();
-const {info: snack} = useSnackbar();
 const {copyToClipboard} = useClipboard();
+
 const search = ref('');
 const tablePolicyRules = ref<HTMLElement | null>(null);
+const rules = ref<PolicyRuleDto[]>([]);
 
-const headers = computed(() => {
+const headers = computed((): DataTableHeader[] => {
   return [
     {
       title: t('COL_ACTIONS'),
       sortable: false,
       align: 'center',
       width: 120,
-      value: 'Actions',
+      value: 'actions',
     },
     {
       title: t('COL_NAME'),
       sortable: true,
       value: 'name',
-      width: '200',
+      width: 200,
     },
     {
       title: t('COL_DESCRIPTION'),
       sortable: false,
       value: 'description',
       align: 'start',
+      width: 180,
     },
   ];
 });
-const rules = ref<PolicyRuleDto[]>([]);
 
 const projectModel = computed(() => projectStore.currentProject!);
 
@@ -109,22 +109,20 @@ const copyRuleToClipboard = (item: PolicyRuleDto) => {
   copyToClipboard(content);
 };
 
-const getActionButtons = (item: PolicyRuleDto): TableActionButtonsProps['buttons'] => {
-  return [
-    {
-      icon: 'mdi-content-copy',
-      hint: t('TT_COPY_REFERENCE_INFO'),
-      event: 'copy',
-      show: true,
-    },
-    {
-      icon: 'mdi-open-in-new',
-      hint: t('TT_open_rule'),
-      event: 'open',
-      show: true,
-    },
-  ];
-};
+const actionButtons = computed((): TableActionButtonsProps['buttons'] => [
+  {
+    icon: 'mdi-content-copy',
+    hint: t('TT_COPY_REFERENCE_INFO'),
+    event: 'copy',
+    show: true,
+  },
+  {
+    icon: 'mdi-open-in-new',
+    hint: t('TT_open_rule'),
+    event: 'open',
+    show: true,
+  },
+]);
 
 onMounted(() => {
   reloadInternal();
@@ -170,10 +168,10 @@ watch(projectModel, async (value) => {
             'items-per-page-options': [10, 50, 100, -1],
           }"
           :item-class="getCssClassForReadonlyRow">
-          <template v-slot:item.Actions="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
-              :buttons="getActionButtons(item)"
+              :buttons="actionButtons"
               @copy="copyRuleToClipboard(item)"
               @open="openRule(item)" />
           </template>

--- a/frontend/libs/portal/components/grids/GridSBOM.vue
+++ b/frontend/libs/portal/components/grids/GridSBOM.vue
@@ -4,11 +4,7 @@
 
 <script setup lang="ts">
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import ConfirmationDialog from '@disclosure-portal/components/dialog/ConfirmationDialog.vue';
-import ReviewRemarkDialog from '@disclosure-portal/components/dialog/ReviewRemarkDialog.vue';
-import SbomValidationErrorsDialog from '@disclosure-portal/components/dialog/SbomValidationErrorsDialog.vue';
 import ErrorDialogConfig from '@disclosure-portal/model/ErrorDialogConfig';
-import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
 import {ApprovableSPDXDto} from '@disclosure-portal/model/Project';
 import {NameKeyIdentifier, VersionSbomsFlat} from '@disclosure-portal/model/ProjectsResponse';
 import {Group} from '@disclosure-portal/model/Rights';
@@ -21,16 +17,15 @@ import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {formatDateAndTime} from '@disclosure-portal/utils/Table';
 import {formatDateTime, formatDateTimeShort, originShort, originTooltip} from '@disclosure-portal/utils/View';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
-import DDateCellWithTooltip from '@shared/components/disco/DDateCellWithTooltip.vue';
-import DIconButton from '@shared/components/disco/DIconButton.vue';
-import DSpdxTagDialog from '@shared/components/disco/DSpdxTagDialog.vue';
-import Tooltip from '@shared/components/disco/Tooltip.vue';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
-import DiscoFileUpload from '@shared/components/widgets/DiscoFileUpload.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
-import TableLayout from '@shared/layouts/TableLayout.vue';
-import {DataTabelIndex, DataTableHeader, DataTableItem, SortItem} from '@shared/types/table';
+import {
+  DataTabelIndex,
+  DataTableHeader,
+  DataTableHeaderFilterItems,
+  DataTableItem,
+  SortItem,
+} from '@shared/types/table';
 import {useClipboard} from '@shared/utils/clipboard';
 import config from '@shared/utils/config';
 import dayjs from 'dayjs';
@@ -67,104 +62,90 @@ const search = ref('');
 const uploadURL = ref('');
 const isBranchSelectionEnabled = ref(true);
 const selectedFilterChannel = ref<string[]>([]);
-const statusFilterOpened = ref(false);
 const selectedBranch = ref<NameKeyIdentifier>({} as NameKeyIdentifier);
 const sortItems = ref<SortItem[]>([{key: 'Uploaded', order: 'desc'}]);
 const confirmConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDialogConfig);
 const confirmVisible = ref(false);
 const {info: snack} = useSnackbar();
 const branches = computed(() => sbomStore.allVersions);
-const reviewRemarkDialog = ref<InstanceType<typeof ReviewRemarkDialog>>();
-const dlgSbomValidationErrors = ref<InstanceType<typeof SbomValidationErrorsDialog>>();
+const reviewRemarkDialog = ref();
+const dlgSbomValidationErrors = ref();
 const helpText = ref('');
-const upload = ref<InstanceType<typeof DiscoFileUpload>>();
+const upload = ref();
 
 const sortByName = (a: SpdxFile, b: SpdxFile): number => {
   return b.MetaInfo.Name.localeCompare(a.MetaInfo.Name);
 };
 
-const headers = (): DataTableHeader[] => {
-  const res: DataTableHeader[] = [
-    {
-      title: t('COL_ACTIONS'),
-      sortable: false,
-      align: 'center',
-      class: 'tableHeaderCell',
-      value: 'Actions',
-      width: 100,
-    },
-    {
-      title: t('COL_SPDX_FILENAME'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'searchIndex',
-      width: 380,
-      sortable: true,
-      sortRaw: sortByName,
-    },
-    {
-      title: t('COL_REVIEW_STATUS'),
-      align: 'center',
-      class: 'tableHeaderCell',
-      value: 'OverallReview',
-      width: 80,
-    },
-  ];
-  if (!props.channelView) {
-    res.push({
-      title: t('COL_SBOM_BRANCH'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'versionName',
-      sortable: true,
-      width: 110,
-    });
-  }
-  res.push(
-    {
-      title: t('COL_SBOM_TAG'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'Tag',
-      sortable: true,
-      width: 100,
-    },
-    {
-      title: t('COL_SBOM_FORMAT'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'MetaInfo.SpdxVersion',
-      sortable: true,
-      width: 100,
-    },
-    {
-      title: t('COL_SBOM_ORIGIN'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'Origin',
-      sortable: true,
-      width: 100,
-    },
-    {
-      title: t('COL_SBOM_UPLOADER'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'Uploader',
-      sortable: true,
-      width: 110,
-    },
-    {
-      title: t('COL_UPLOADED'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'Uploaded',
-      sortable: true,
-      width: 110,
-    },
-  );
-
-  return res;
-};
+const headers = computed((): DataTableHeader[] => [
+  {
+    title: t('COL_ACTIONS'),
+    sortable: false,
+    align: 'center',
+    value: 'actions',
+    width: 100,
+  },
+  {
+    title: t('COL_SPDX_FILENAME'),
+    align: 'start',
+    value: 'searchIndex',
+    width: 380,
+    sortable: true,
+    sortRaw: sortByName,
+  },
+  {
+    title: t('COL_REVIEW_STATUS'),
+    align: 'center',
+    value: 'OverallReview',
+    width: 80,
+  },
+  ...(!props.channelView
+    ? [
+      {
+        title: t('COL_SBOM_BRANCH'),
+        align: 'start',
+        value: 'versionName',
+        sortable: true,
+        width: 110,
+      } as DataTableHeader,
+    ]
+    : []),
+  {
+    title: t('COL_SBOM_TAG'),
+    align: 'start',
+    value: 'Tag',
+    sortable: true,
+    width: 130,
+  },
+  {
+    title: t('COL_SBOM_FORMAT'),
+    align: 'start',
+    value: 'MetaInfo.SpdxVersion',
+    sortable: true,
+    width: 100,
+  },
+  {
+    title: t('COL_SBOM_ORIGIN'),
+    align: 'start',
+    value: 'Origin',
+    sortable: true,
+    width: 100,
+  },
+  {
+    title: t('COL_SBOM_UPLOADER'),
+    align: 'start',
+    value: 'Uploader',
+    sortable: true,
+    width: 110,
+  },
+  {
+    title: t('COL_UPLOADED'),
+    align: 'start',
+    value: 'Uploaded',
+    sortable: true,
+    width: 110,
+  },
+]);
 
 const items = computed((): DataTableItems[] => {
   const getSearchIndex = (file: VersionSbomsFlat) => {
@@ -193,20 +174,18 @@ const filteredList = computed((): DataTableItems[] => {
   return items.value.filter(filterOnChannel);
 });
 
-const possibleChannels = computed((): IDefaultSelectItem[] => {
+const possibleChannels = computed((): DataTableHeaderFilterItems[] => {
   if (!items.value) {
     return [];
   }
 
-  return _.chain(items.value)
-    .uniqBy((item: VersionSbomsFlat) => item.versionName)
-    .map((item: VersionSbomsFlat) => {
-      return {
-        text: item.versionName,
-        value: item.versionName,
-      } as IDefaultSelectItem;
-    })
-    .value();
+  const uniqueVersionNames = [...new Set(items.value.map((item: VersionSbomsFlat) => item.versionName))];
+
+  return uniqueVersionNames.map((value: string) => {
+    return {
+      value,
+    } as DataTableHeaderFilterItems;
+  });
 });
 
 const isOwnerOrDomainAdmin = computed(
@@ -525,103 +504,58 @@ const getActionButtons = (item: VersionSbomsFlat): TableActionButtonsProps['butt
           fixed-header
           :sort-by="sortItems"
           :search="search"
-          :headers="headers()"
+          :headers="headers"
           :items="filteredList"
           @click:row="openSBOM"
           :footer-props="{
             'items-per-page-options': [10, 50, 100, -1],
           }"
           class="striped-table fill-height">
-          <template v-slot:[`header.versionName`]="{column, getSortIcon, toggleSort}">
-            <div class="v-data-table-header__content">
-              <span>{{ column.title }}</span>
-              <v-menu :close-on-content-click="false" v-model="statusFilterOpened">
-                <template v-slot:activator="{props}">
-                  <DIconButton
-                    :parentProps="props"
-                    icon="mdi-filter-variant"
-                    :hint="t('TT_SHOW_FILTER')"
-                    :color="selectedFilterChannel.length > 0 ? 'primary' : 'default'"
-                    location="top" />
-                </template>
-                <div class="bg-background" style="width: 280px">
-                  <v-row class="d-flex ma-1 mr-2 justify-end">
-                    <DIconButton icon="mdi-close" @clicked="statusFilterOpened = false" color="default" />
-                  </v-row>
-                  <v-select
-                    v-model="selectedFilterChannel"
-                    :items="possibleChannels"
-                    class="pa-2 mx-2 pb-4"
-                    :label="t('Lbl_filter_branches')"
-                    clearable
-                    multiple
-                    item-title="text"
-                    item-value="value"
-                    variant="outlined"
-                    density="compact"
-                    menu
-                    transition="scale-transition"
-                    persistent-clear
-                    :list-props="{class: 'striped-filter-dd py-0'}">
-                    <template v-slot:item="{props}">
-                      <v-list-item v-bind="props" class="px-2 py-0">
-                        <template v-slot:prepend="{isSelected}">
-                          <v-checkbox hide-details :model-value="isSelected" />
-                        </template>
-                        <template v-slot:title="{title}">
-                          <span class="pFilterEntry">
-                            {{ title }}
-                          </span>
-                        </template>
-                      </v-list-item>
-                    </template>
-                    <template v-slot:selection="{item, index}">
-                      <div v-if="index === 0" class="d-flex align-center">
-                        <span class="pFilterEntry">{{ item.title }}</span>
-                      </div>
-                      <span v-if="index === 1" class="pAdditionalFilter">
-                        +{{ selectedFilterChannel.length - 1 }} others
-                      </span>
-                    </template>
-                  </v-select>
-                </div>
-              </v-menu>
-              <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-            </div>
+          <template #[`header.versionName`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterChannel"
+                  :column="column"
+                  :label="t('COL_SBOM_BRANCH')"
+                  :allItems="possibleChannels">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
-          <template v-slot:[`item.searchIndex`]="{item}">
+          <template #[`item.searchIndex`]="{item}">
             {{ formatDateTime(item.Uploaded) }} -&nbsp;{{ item.MetaInfo.Name }}
             <br />
             <span class="font-weight-bold">UUID: </span>
             <span>{{ item._key }}</span>
             <br v-if="item.ApprovalInfo && item.ApprovalInfo.Status" />
             <span class="font-weight-bold" v-if="item.ApprovalInfo && item.ApprovalInfo.Status">{{
-              t(`SBOM_STATUS_${item.ApprovalInfo.Status}`)
-            }}</span>
+                t(`SBOM_STATUS_${item.ApprovalInfo.Status}`)
+              }}</span>
             <span v-if="item.ApprovalInfo && item.ApprovalInfo.Status">
               <v-icon
                 small
                 v-if="item.ApprovalInfo && item.ApprovalInfo.Comment && item.ApprovalInfo.Comment.length > 0"
-                >chevron_right</v-icon
+              >chevron_right</v-icon
               >
               {{ item.ApprovalInfo.Comment }}</span
             >
             <br v-if="item.IsToDelete" />
             <span v-if="item.IsToDelete" class="font-weight-bold text-[rgb(var(--v-theme-error))]">{{
-              t('SBOM_ABOUT_DELETION_NOTE')
-            }}</span>
+                t('SBOM_ABOUT_DELETION_NOTE')
+              }}</span>
             <br v-if="item.IsToRetain" />
             <span v-if="item.IsToRetain" class="font-weight-bold text-[rgb(var(--v-theme-success))]">{{
-              t('SBOM_MARKED_FOR_RETENTION')
-            }}</span>
+                t('SBOM_MARKED_FOR_RETENTION')
+              }}</span>
           </template>
-          <template v-slot:[`item.OverallReview`]="{item}">
+          <template #[`item.OverallReview`]="{item}">
             <DOverallStateIcon v-if="item.OverallReview" :review="item.OverallReview" />
           </template>
-          <template v-slot:[`item.Uploaded`]="{item}">
+          <template #[`item.Uploaded`]="{item}">
             <DDateCellWithTooltip :value="item.Uploaded" />
           </template>
-          <template v-slot:[`item.Tag`]="{item}">
+          <template #[`item.Tag`]="{item}">
             <v-chip
               v-if="
                 item.ApprovalInfo.IsInApproval ||
@@ -657,7 +591,7 @@ const getActionButtons = (item: VersionSbomsFlat): TableActionButtonsProps['butt
             </Tooltip>
             <span v-else>{{ item.Origin }}</span>
           </template>
-          <template v-slot:[`item.Actions`]="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
               :buttons="getActionButtons(item)"

--- a/frontend/libs/portal/components/grids/GridVersions.vue
+++ b/frontend/libs/portal/components/grids/GridVersions.vue
@@ -4,7 +4,6 @@
 
 <script setup lang="ts">
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
 import {OverallReview, OverallReviewState, VersionSlim} from '@disclosure-portal/model/VersionDetails';
 import versionService from '@disclosure-portal/services/version';
 import {useAppStore} from '@disclosure-portal/stores/app';
@@ -12,9 +11,9 @@ import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import {useSbomStore} from '@disclosure-portal/stores/sbom.store';
 import {formatDateAndTime, getOverallReviewTranslationKey} from '@disclosure-portal/utils/Table';
 import {getStrWithMaxLength, openUrl} from '@disclosure-portal/utils/View';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
-import {DataTableHeader, DataTableItem} from '@shared/types/table';
+import {DataTableHeader, DataTableHeaderFilterItems, DataTableItem} from '@shared/types/table';
 import {useClipboard} from '@shared/utils/clipboard';
 import {TOOLTIP_OPEN_DELAY_IN_MS} from '@shared/utils/constant';
 import dayjs from 'dayjs';
@@ -23,6 +22,7 @@ import {computed, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRouter} from 'vue-router';
 import {SortItem} from 'vuetify/lib/components/VDataTable/composables/sort';
+import {getIconColor, getVersionStateIcon} from '@disclosure-portal/utils/Table';
 
 const {t} = useI18n();
 const {info} = useSnackbar();
@@ -36,70 +36,72 @@ const labelTools = computed(() => appStore.getLabelsTools);
 
 const search = ref('');
 const selectedFilterStatus = ref<string[]>([]);
-const statusFilterOpened = ref(false);
 const confirmConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDialogConfig);
 const versionDialog = ref();
 const confirmVisible = ref(false);
 
 const maxVersions = 10;
 
-const headers = computed((): DataTableHeader[] => {
-  const res: DataTableHeader[] = [
-    {
-      title: t('COL_STATUS'),
-      sortable: true,
-      align: 'center',
-      width: 110,
-      value: 'status',
-    },
-    {
-      title: t('COL_VERSION'),
-      key: 'name',
-      width: 130,
-      align: 'start',
-    },
-    {
-      title: t('COL_DESCRIPTION'),
-      key: 'description',
-      align: 'start',
-      width: 300,
-      sortable: false,
-    },
-    {
-      title: t('COL_CREATED'),
-      key: 'created',
-      align: 'start',
-      width: 120,
-    },
-    {
-      title: t('COL_UPDATED'),
-      key: 'updated',
-      align: 'start',
-      width: 120,
-    },
-  ];
-  if (
+const showActions = computed(
+  () =>
     currentProject.value?.allowProjectRead ||
     currentProject.value?.allowProjectEdit ||
-    currentProject.value?.allowProjectDelete
-  ) {
-    res.unshift({
-      title: t('COL_ACTIONS'),
-      key: 'actions',
-      align: 'center',
-      width: 100,
-      sortable: false,
-    });
-  }
-  return res;
-});
+    currentProject.value?.allowProjectDelete,
+);
+
+const headers = computed((): DataTableHeader[] => [
+  ...(showActions.value
+    ? [
+      {
+        title: t('COL_ACTIONS'),
+        key: 'actions',
+        align: 'center',
+        width: 100,
+        sortable: false,
+      } as DataTableHeader,
+    ]
+    : []),
+  {
+    title: t('COL_STATUS'),
+    sortable: true,
+    align: 'center',
+    width: 110,
+    value: 'status',
+  },
+  {
+    title: t('COL_VERSION'),
+    key: 'name',
+    width: 130,
+    align: 'start',
+  },
+  {
+    title: t('COL_DESCRIPTION'),
+    key: 'description',
+    align: 'start',
+    width: 300,
+    sortable: false,
+  },
+  {
+    title: t('COL_CREATED'),
+    key: 'created',
+    align: 'start',
+    width: 120,
+  },
+  {
+    title: t('COL_UPDATED'),
+    key: 'updated',
+    align: 'start',
+    width: 120,
+  },
+]);
+
 const versions = computed((): VersionSlim[] => {
   return Object.values(currentProject.value?.versions ?? []);
 });
 const filteredList = computed((): VersionSlim[] => {
   return Array.isArray(versions.value) ? versions.value.filter(filterOnStatus) : [];
 });
-const possibleStatuses = computed((): IDefaultSelectItem[] => {
+const possibleStatuses = computed((): DataTableHeaderFilterItems[] => {
   if (!versions.value) {
     return [];
   }
@@ -116,14 +118,18 @@ const possibleStatuses = computed((): IDefaultSelectItem[] => {
         return {
           text: t(getOverallReviewTranslationKey(item.status)),
           value: item.status,
-        } as IDefaultSelectItem;
+          iconColor: getIconColor(item.status),
+          icon: getVersionStateIcon(item.status),
+        } as DataTableHeaderFilterItems;
       }
       const recentOverallReview = getRecentOverallReview(item.overallReviews);
       const status = !recentOverallReview || !recentOverallReview.state ? 'new' : item.status;
       return {
         text: t(getOverallReviewTranslationKey(status)),
         value: status,
-      } as IDefaultSelectItem;
+        iconColor: getIconColor(status),
+        icon: getVersionStateIcon(status),
+      } as DataTableHeaderFilterItems;
     })
     .value();
 });
@@ -216,7 +222,7 @@ const editVersion = (item: VersionSlim) => {
   });
 };
 
-const getActionButtons = (): TableActionButtonsProps['buttons'] => {
+const actionButtons = computed((): TableActionButtonsProps['buttons'] => {
   return [
     {
       icon: 'mdi-content-copy',
@@ -237,7 +243,7 @@ const getActionButtons = (): TableActionButtonsProps['buttons'] => {
       show: currentProject.value?.allowProjectDelete,
     },
   ];
-};
+});
 </script>
 
 <template>
@@ -275,91 +281,45 @@ const getActionButtons = (): TableActionButtonsProps['buttons'] => {
           :search="search"
           :headers="headers"
           :items="filteredList"
-          @click:row="openVersion"
+          class="striped-table fill-height"
+          density="compact"
           :footer-props="{
             'items-per-page-options': [10, 50, 100, -1],
           }"
-          class="striped-table fill-height"
-          density="compact">
-          <template v-slot:[`header.status`]="{column, getSortIcon, toggleSort}">
-            <div class="v-data-table-header__content">
-              <span>{{ column.title }}</span>
-              <v-menu :close-on-content-click="false" v-model="statusFilterOpened">
-                <template v-slot:activator="{props}">
-                  <DIconButton
-                    :parentProps="props"
-                    icon="mdi-filter-variant"
-                    :hint="t('TT_SHOW_FILTER')"
-                    :color="selectedFilterStatus.length > 0 ? 'primary' : 'default'" />
-                </template>
-                <div class="bg-background" style="width: 280px">
-                  <v-row class="d-flex ma-1 mr-2 justify-end">
-                    <DIconButton icon="mdi-close" @clicked="statusFilterOpened = false" color="default" />
-                  </v-row>
-                  <v-select
-                    v-model="selectedFilterStatus"
-                    :items="possibleStatuses"
-                    class="pa-2 mx-2 pb-4"
-                    :label="t('Lbl_filter_status')"
-                    clearable
-                    multiple
-                    item-title="text"
-                    item-value="value"
-                    variant="outlined"
-                    density="compact"
-                    menu
-                    transition="scale-transition"
-                    persistent-clear
-                    :list-props="{class: 'striped-filter-dd py-0'}">
-                    <template v-slot:item="{item, props}">
-                      <v-list-item v-bind="props" class="px-2 py-0">
-                        <template v-slot:prepend="{isSelected}">
-                          <v-checkbox hide-details :model-value="isSelected" />
-                        </template>
-                        <template v-slot:title="{title}">
-                          <span :class="'pvStatus' + (!item.value ? 'new' : item.value) + ' pStatusFilter'">
-                            {{ title }}</span
-                          >
-                        </template>
-                      </v-list-item>
-                    </template>
-                    <template v-slot:selection="{item, index}">
-                      <div v-if="index === 0" class="d-flex align-center">
-                        <span :class="'pvStatus' + (!item.value ? 'new' : item.value) + ' pStatusFilter'">{{
-                          !item.value ? 'new' : item.title
-                        }}</span>
-                      </div>
-                      <span v-if="index === 1" class="pAdditionalFilter">
-                        +{{ selectedFilterStatus.length - 1 }} others
-                      </span>
-                    </template>
-                  </v-select>
-                </div>
-              </v-menu>
-              <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-            </div>
+          @click:row="openVersion">
+          <template #[`header.status`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterStatus"
+                  :column="column"
+                  :label="t('COL_STATUS')"
+                  :allItems="possibleStatuses">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
-          <template v-slot:[`item.status`]="{item}">
+          <template #[`item.status`]="{item}">
             <DVersionStateWithTooltip :version="item"></DVersionStateWithTooltip>
           </template>
-          <template v-slot:[`item.created`]="{item}">
+          <template #[`item.created`]="{item}">
             <DDateCellWithTooltip :value="item.created" />
           </template>
-          <template v-slot:[`item.updated`]="{item}">
+          <template #[`item.updated`]="{item}">
             <DDateCellWithTooltip :value="item.updated" />
           </template>
-          <template v-slot:[`item.description`]="{item}">
+          <template #[`item.description`]="{item}">
             <v-tooltip :open-delay="TOOLTIP_OPEN_DELAY_IN_MS" bottom max-width="480" content-class="dpTooltip">
-              <template v-slot:activator="{props}">
+              <template #activator="{props}">
                 <span v-bind="props"> {{ getStrWithMaxLength(120, '' + item.description) }}</span>
               </template>
               {{ '' + item.description }}
             </v-tooltip>
           </template>
-          <template v-slot:[`item.actions`]="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
-              :buttons="getActionButtons(item)"
+              :buttons="actionButtons"
               @copy="copyVersionToClipboard(item)"
               @edit="editVersion(item)"
               @delete="showConfirm(item)" />

--- a/frontend/libs/portal/components/projects/GridProjects.vue
+++ b/frontend/libs/portal/components/projects/GridProjects.vue
@@ -51,11 +51,10 @@ const filteredList = computed<ProjectSlim[]>(() => {
   }
   return result;
 });
-const headers = computed<DataTableHeader[]>(() => [
-  {title: '', value: 'data-table-expand', width: '38'},
-  {title: t('COL_ACTIONS'), align: 'center', width: 80, value: 'actions', sortable: false},
-  {title: t('COL_STATUS'), sortable: true, value: 'status', width: '120'},
-  {title: t('COL_GROUP'), align: 'center', sortable: true, value: 'isGroup', width: '120'},
+const headers = computed((): DataTableHeader[] => [
+  {title: t('COL_ACTIONS'), align: 'center', width: 160, value: 'actions', sortable: false},
+  {title: t('COL_STATUS'), sortable: true, value: 'status', width: 120},
+  {title: t('COL_GROUP'), align: 'center', sortable: true, value: 'isGroup', width: 120},
   {title: t('COL_NAME'), align: 'start', value: 'name', width: 270, sortable: true},
   {title: t('COL_DEVELOPER_COMPANY'), align: 'start', width: 270, value: 'supplier', sortable: true},
   {title: t('COL_OWNER_COMPANY'), align: 'start', width: 270, value: 'company', sortable: true},
@@ -93,9 +92,9 @@ const isExpanded = (item: ProjectSlim) => {
   return expanded.value.includes(item._key);
 };
 
-const customFilterTable = (rawCellValue: unknown, search: string, internalItem: any) => {
+const customFilterTable = (rawCellValue: unknown, searchTerm: string, internalItem: any) => {
   const project = internalItem.raw as ProjectSlim;
-  const lowerSearch = search.toLowerCase();
+  const lowerSearch = searchTerm.toLowerCase();
 
   const foundPolicy = project.policyLabels.some((l) => {
     const labelStr = labelTools.value.policyLabelsMap[l].name;
@@ -115,8 +114,8 @@ const customFilterTable = (rawCellValue: unknown, search: string, internalItem: 
       .indexOf(lowerSearch) !== -1;
 
   let foundCustomIds: boolean;
-  if (search.includes(':')) {
-    const [customIdSearch, valueSearch] = search.split(':').map((s) => s.trim().toLowerCase());
+  if (searchTerm.includes(':')) {
+    const [customIdSearch, valueSearch] = searchTerm.split(':').map((s) => s.trim().toLowerCase());
     foundCustomIds = project.customIds.some((id) => {
       return (
         id.technicalId.toLowerCase().indexOf(customIdSearch) !== -1 &&
@@ -195,7 +194,7 @@ const customFilterTable = (rawCellValue: unknown, search: string, internalItem: 
           v-model:search="search"
           v-model:expanded="expanded"
           @click:row="onRowClick">
-          <template v-slot:[`header.status`]="{column, getSortIcon, toggleSort}">
+          <template #[`header.status`]="{column, getSortIcon, toggleSort}">
             <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
               <template #filter>
                 <GridHeaderFilterIcon
@@ -208,11 +207,11 @@ const customFilterTable = (rawCellValue: unknown, search: string, internalItem: 
               </template>
             </GridFilterHeader>
           </template>
-          <template v-slot:[`header.isGroup`]="{column, getSortIcon, toggleSort}">
+          <template #[`header.isGroup`]="{column, getSortIcon, toggleSort}">
             <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
               <template #filter>
                 <v-menu offset-y :close-on-content-click="false" v-model="menuIsGroup">
-                  <template v-slot:activator="{props}">
+                  <template #activator="{props}">
                     <span>
                       <v-icon class="mr-1" v-bind="props" :color="filterGroups ? 'primary' : 'default'">
                         mdi-filter-variant
@@ -230,51 +229,53 @@ const customFilterTable = (rawCellValue: unknown, search: string, internalItem: 
               </template>
             </GridFilterHeader>
           </template>
-          <template v-slot:[`item.updated`]="{item}">
+          <template #[`item.updated`]="{item}">
             <DDateCellWithTooltip :value="item.updated"></DDateCellWithTooltip>
           </template>
-          <template v-slot:[`item.created`]="{item}">
+          <template #[`item.created`]="{item}">
             <DDateCellWithTooltip :value="item.created"></DDateCellWithTooltip>
           </template>
-          <template v-slot:[`item.status`]="{item}">
-            <span :style="{color: projectsUtils.getTextStatusColor(item.status)}">
+          <template #[`item.status`]="{item}">
+            <span class="font-bold" :style="{color: projectsUtils.getTextStatusColor(item.status)}">
               {{ t('STATUS_' + (!item.status ? 'new' : item.status)) }}
             </span>
           </template>
-          <template v-slot:[`item.isGroup`]="{item}">
+          <template #[`item.isGroup`]="{item}">
             <v-icon icon="mdi-check" class="mr-2" :color="item.isGroup ? 'primary' : 'tableBorderColor'"></v-icon>
           </template>
-          <template v-slot:[`item.actions`]="{item}">
-            <ProjectsTableAction :item="item" @reload="reload"></ProjectsTableAction>
+          <template #[`item.actions`]="{item}">
+            <div class="flex items-center justify-start">
+              <DIconButton
+                :icon="isExpanded(item) ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                color="primary"
+                class="size-10"
+                @clicked="toggleExpand(item)" />
+              <ProjectsTableAction :item="item" @reload="reload"></ProjectsTableAction>
+            </div>
           </template>
-          <template v-slot:[`item.company`]="{item}">
+          <template #[`item.company`]="{item}">
             <span v-if="!item.missing">{{ item.company }}</span>
             <div v-else>
               <v-icon class="pr-2" icon="mdi-alert" color="warning" small></v-icon>
               <span>{{ t('WARNING_MISSING_DEPT') }}</span>
             </div>
           </template>
-          <template v-slot:[`item.department`]="{item}">
+          <template #[`item.department`]="{item}">
             <span v-if="!item.missing">{{ item.department }}</span>
             <div v-else>
               <v-icon class="pr-2" color="warning" icon="mdi-alert" small></v-icon>
               <span>{{ t('WARNING_MISSING_DEPT') }}</span>
             </div>
           </template>
-          <template v-slot:[`item.supplier`]="{item}">
+          <template #[`item.supplier`]="{item}">
             <span v-if="!item.supplierMissing">{{ item.supplier }}</span>
             <div v-else>
               <v-icon class="pr-2" color="warning" icon="mdi-alert" small></v-icon>
               <span>{{ t('WARNING_MISSING_DEPT') }}</span>
             </div>
           </template>
-          <template v-slot:[`item.data-table-expand`]="{item}">
-            <v-icon color="primary" @click.stop="toggleExpand(item)">
-              {{ isExpanded(item) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-            </v-icon>
-          </template>
 
-          <template v-slot:expanded-row="{item}">
+          <template #expanded-row="{item}">
             <td :colspan="headers.length" class="bg-table-header h-full cursor-default overflow-y-clip">
               <GridProjectsExpandContent :item="item" :is-async="false" />
             </td>
@@ -284,6 +285,7 @@ const customFilterTable = (rawCellValue: unknown, search: string, internalItem: 
     </template>
   </TableLayout>
 </template>
+
 <style scoped lang="scss">
 .bg-table-header {
   @apply bg-[rgb(var(--v-theme-tableHeaderBackgroundColor))];

--- a/frontend/libs/portal/components/projects/projectsDetail/TabProjectChildrenUserManagement.vue
+++ b/frontend/libs/portal/components/projects/projectsDetail/TabProjectChildrenUserManagement.vue
@@ -4,14 +4,9 @@
 
 <script setup lang="ts">
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import ConfirmationDialog from '@disclosure-portal/components/dialog/ConfirmationDialog.vue';
 import {ErrorDialogInterface} from '@disclosure-portal/components/dialog/DialogInterfaces';
-import ErrorDialog from '@disclosure-portal/components/dialog/ErrorDialog.vue';
-import NewUserDialog from '@disclosure-portal/components/dialog/NewUserDialog.vue';
-import ProjectChildrenMembersAddedDialog from '@disclosure-portal/components/dialog/ProjectChildrenMembersAddedDialog.vue';
 import DHTTPError from '@disclosure-portal/model/DHTTPError';
 import ErrorDialogConfig from '@disclosure-portal/model/ErrorDialogConfig';
-import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
 import {
   IProjectChildrenMembers,
   ProjectChildMemberCombi,
@@ -24,11 +19,9 @@ import projectService from '@disclosure-portal/services/projects';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {getCssClassForTableRow} from '@disclosure-portal/utils/Table';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
-import DIconButton from '@shared/components/disco/DIconButton.vue';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
-import {DataTableHeader} from '@shared/types/table';
+import {DataTableHeader, DataTableHeaderFilterItems, SortItem} from '@shared/types/table';
 import _, {indexOf} from 'lodash';
 import {computed, onMounted, ref, watch} from 'vue';
 import {useI18n} from 'vue-i18n';
@@ -40,9 +33,7 @@ const {info} = useSnackbar();
 
 const dataAreLoaded = ref(false);
 const projectChildrenMembers = ref<IProjectChildrenMembers>({} as IProjectChildrenMembers);
-const menu = ref(false);
 const selectedFilterUserType = ref<string[]>([]);
-const possibleUserTypes = ref<IDefaultSelectItem[]>([]);
 const search = ref('');
 const userDialogVisible = ref(false);
 const projectChildrenMembersAddedVisible = ref(false);
@@ -62,70 +53,60 @@ const route = useRoute();
 
 const projectModel = computed(() => projectStore.currentProject!);
 
-const userHeaders = computed<DataTableHeader[]>(() => {
-  const res: DataTableHeader[] = [
-    {
-      title: t('COL_USER'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'projectMember.userId',
-      width: 420,
-    },
-    {
-      title: t('COL_USER_TYPE'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'projectMember.userType',
-      width: 160,
-    },
-    {
-      title: t('COL_USER_ROLE'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'projectMember.responsible',
-      width: 160,
-    },
-    {
-      title: t('COL_USER_COMMENT'),
-      align: 'start',
-      sortable: true,
-      width: 160,
-      class: 'tableHeaderCell',
-      value: 'projectMember.comment',
-    },
-    {
-      title: t('PROJECT'),
-      align: 'start',
-      filterable: true,
-      class: 'tableHeaderCell',
-      width: 160,
-      value: 'projectName',
-    },
-  ];
-  if (projectModel.value.allowUserManagementUpdate || projectModel.value.allowUserManagementDelete) {
-    res.unshift({
-      title: t('COL_ACTIONS'),
-      align: 'center',
-      filterable: true,
-      sortable: false,
-      class: 'tableHeaderCell',
-      value: 'actions',
-      width: 120,
-    });
-  }
-  return res;
-});
+const userHeaders = computed((): DataTableHeader[] => [
+  ...(projectModel.value.allowUserManagementUpdate || projectModel.value.allowUserManagementDelete
+    ? [
+      {
+        title: t('COL_ACTIONS'),
+        align: 'center',
+        sortable: false,
+        value: 'actions',
+        width: 120,
+      } as DataTableHeader,
+    ]
+    : []),
+  {
+    title: t('COL_USER'),
+    align: 'start',
+    sortable: true,
+    value: 'projectMember.userId',
+    width: 420,
+  },
+  {
+    title: t('COL_USER_TYPE'),
+    align: 'start',
+    sortable: true,
+    value: 'projectMember.userType',
+    width: 160,
+  },
+  {
+    title: t('COL_USER_ROLE'),
+    align: 'start',
+    sortable: true,
+    value: 'projectMember.responsible',
+    width: 160,
+  },
+  {
+    title: t('COL_USER_COMMENT'),
+    align: 'start',
+    sortable: true,
+    width: 160,
+    value: 'projectMember.comment',
+  },
+  {
+    title: t('PROJECT'),
+    align: 'start',
+    width: 160,
+    value: 'projectName',
+  },
+]);
 
-const sortItems = () => [{key: 'projectMember.created', order: 'asc' as const}] as const;
+const sortItems: SortItem[] = [{key: 'projectMember.created', order: 'asc'}];
 
 const reload = async () => {
   dataAreLoaded.value = false;
   if (projectModel.value._key) {
     projectChildrenMembers.value = await projectService.getChildrenMembers(projectModel.value._key);
-    possibleUserTypes.value = getPossibleUserTypes();
   }
   dataAreLoaded.value = true;
 };
@@ -308,20 +289,21 @@ const filterOnType = (item: ProjectChildMemberCombi): boolean => {
   );
 };
 
-const getPossibleUserTypes = (): IDefaultSelectItem[] => {
-  if (!projectChildrenMembers.value) {
+const possibleUserTypes = computed((): DataTableHeaderFilterItems[] => {
+  if (!projectChildrenMembers.value?.list) {
     return [];
   }
-  return _.chain(projectChildrenMembers.value.list)
-    .uniqBy('projectMember.userType')
-    .map((item: ProjectChildMemberCombi) => {
-      return {
-        text: item.projectMember.userType,
-        value: item.projectMember.userType,
-      } as IDefaultSelectItem;
-    })
-    .value();
-};
+
+  const uniqueUserTypes = [
+    ...new Set(projectChildrenMembers.value?.list?.map((item) => item?.projectMember?.userType)),
+  ];
+
+  return uniqueUserTypes.map(
+    (value): DataTableHeaderFilterItems => ({
+      value,
+    }),
+  );
+});
 
 const customFilterTable = (value: any, search: string, internalItem: any) => {
   const item = internalItem.raw;
@@ -346,7 +328,7 @@ const customFilterTable = (value: any, search: string, internalItem: any) => {
   return value.toLowerCase().indexOf(lowerSearch) !== -1;
 };
 
-const getActionButtons = (item: ProjectChildMemberCombi): TableActionButtonsProps['buttons'] => {
+const actionButtons = computed((): TableActionButtonsProps['buttons'] => {
   return [
     {
       icon: 'mdi-pencil',
@@ -361,7 +343,7 @@ const getActionButtons = (item: ProjectChildMemberCombi): TableActionButtonsProp
       show: projectModel.value.allowUserManagementDelete,
     },
   ];
-};
+});
 
 onMounted(async () => {
   await reload();
@@ -408,93 +390,54 @@ watch(
         hide-details></v-text-field>
     </template>
     <template #table>
-      <v-data-table
-        density="compact"
-        :loading="!dataAreLoaded"
-        fixed-header
-        :height="tableHeight"
-        class="striped-table custom-data-table h-full"
-        :headers="userHeaders"
-        :items="filteredList"
-        :sort-by="sortItems()"
-        :item-class="getCssClassForTableRow"
-        :search="search"
-        :custom-filter="customFilterTable">
-        <template v-slot:[`header.projectMember.userType`]="{column, getSortIcon, toggleSort}">
-          <div class="v-data-table-header__content">
-            <span>{{ column.title }}</span>
-            <v-menu :close-on-content-click="false" v-model="menu">
-              <template v-slot:activator="{props}">
-                <DIconButton
-                  :parentProps="props"
-                  icon="mdi-filter-variant"
-                  :hint="t('TT_SHOW_FILTER')"
-                  :color="selectedFilterUserType.length > 0 ? 'primary' : 'default'" />
-              </template>
-              <div class="bg-background" style="width: 280px">
-                <v-row class="d-flex ma-1 mr-2 justify-end">
-                  <DIconButton icon="mdi-close" @clicked="menu = false" color="default" />
-                </v-row>
-                <v-select
+      <div class="fill-height">
+        <v-data-table
+          density="compact"
+          :loading="!dataAreLoaded"
+          fixed-header
+          :height="tableHeight"
+          class="striped-table custom-data-table h-full"
+          :headers="userHeaders"
+          :items="filteredList"
+          :sort-by="sortItems"
+          :item-class="getCssClassForTableRow"
+          :search="search"
+          :custom-filter="customFilterTable">
+          <template #[`header.projectMember.userType`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
                   v-model="selectedFilterUserType"
-                  :items="possibleUserTypes"
-                  class="pa-2 mx-2 pb-4"
-                  :label="t('Lbl_filter_userType')"
-                  clearable
-                  multiple
-                  item-title="text"
-                  item-value="value"
-                  variant="outlined"
-                  density="compact"
-                  menu
-                  transition="scale-transition"
-                  persistent-clear
-                  :list-props="{class: 'striped-filter-dd py-0'}">
-                  <template v-slot:item="{props}">
-                    <v-list-item v-bind="props" class="px-2 py-0">
-                      <template v-slot:prepend="{isSelected}">
-                        <v-checkbox hide-details :model-value="isSelected" />
-                      </template>
-                      <template v-slot:title="{title}">
-                        <span class="pStatusFilterEntry"> {{ title }}</span>
-                      </template>
-                    </v-list-item>
-                  </template>
-                  <template v-slot:selection="{item, index}">
-                    <div v-if="index === 0" class="d-flex align-center">
-                      <span class="pStatusFilterEntry">{{ item.title }}</span>
-                    </div>
-                    <span v-if="index === 1" class="pAdditionalFilter">
-                      +{{ selectedFilterUserType.length - 1 }} others
-                    </span>
-                  </template>
-                </v-select>
-              </div>
-            </v-menu>
-            <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-          </div>
-        </template>
-        <template v-slot:[`item.projectMember.userId`]="{item}">
-          <span v-if="item.projectMember.userProfile.user">
-            {{ item.projectMember.userProfile.lastname }}, {{ item.projectMember.userProfile.forename }} ({{
-              item.projectMember.userProfile.user
-            }})
-          </span>
-          <span v-else>{{ item.projectMember.userId }}</span>
-        </template>
-        <template v-slot:[`item.projectMember.responsible`]="{item}">
-          <span v-if="item.projectMember.responsible">{{ t('COL_USER_ROLE_RESPONSIBLE') }}</span>
-        </template>
-        <template v-slot:[`item.actions`]="{item}">
-          <TableActionButtons
-            variant="compact"
-            :buttons="getActionButtons(item)"
-            @edit="showEditUserDialog(item)"
-            @remove="showDeleteUserDialog(item)" />
-        </template>
-      </v-data-table>
+                  :column="column"
+                  :label="t('COL_USER_TYPE')"
+                  :allItems="possibleUserTypes">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
+          </template>
+          <template #[`item.projectMember.userId`]="{item}">
+            <span v-if="item.projectMember.userProfile.user">
+              {{ item.projectMember.userProfile.lastname }}, {{ item.projectMember.userProfile.forename }} ({{
+                item.projectMember.userProfile.user
+              }})
+            </span>
+            <span v-else>{{ item.projectMember.userId }}</span>
+          </template>
+          <template #[`item.projectMember.responsible`]="{item}">
+            <span v-if="item.projectMember.responsible">{{ t('COL_USER_ROLE_RESPONSIBLE') }}</span>
+          </template>
+          <template #[`item.actions`]="{item}">
+            <TableActionButtons
+              variant="compact"
+              :buttons="actionButtons"
+              @edit="showEditUserDialog(item)"
+              @remove="showDeleteUserDialog(item)" />
+          </template>
+        </v-data-table>
+      </div>
     </template>
   </TableLayout>
+
   <template>
     <NewUserDialog
       ref="userDialogRef"

--- a/frontend/libs/portal/components/projects/projectsDetail/TabProjectTokenManagement.vue
+++ b/frontend/libs/portal/components/projects/projectsDetail/TabProjectTokenManagement.vue
@@ -4,21 +4,14 @@
 
 <script setup lang="ts">
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import ConfirmationDialog from '@disclosure-portal/components/dialog/ConfirmationDialog.vue';
-import CreateTokenDialog from '@disclosure-portal/components/dialog/CreateTokenDialog.vue';
-import TokenIssuedDialog from '@disclosure-portal/components/dialog/TokenIssuedDialog.vue';
-import {IDefaultSelectItem} from '@disclosure-portal/model/IObligation';
 import {Token} from '@disclosure-portal/model/Project';
 import projectService from '@disclosure-portal/services/projects';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import {getCssClassForTableRow} from '@disclosure-portal/utils/Table';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
-import DDateCellWithTooltip from '@shared/components/disco/DDateCellWithTooltip.vue';
-import DIconButton from '@shared/components/disco/DIconButton.vue';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
 import TableLayout from '@shared/layouts/TableLayout.vue';
-import {DataTableHeader, SortItem} from '@shared/types/table';
+import {DataTableHeader, DataTableHeaderFilterItems, SortItem} from '@shared/types/table';
 import _ from 'lodash';
 import {computed, onMounted, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
@@ -26,63 +19,11 @@ import {useI18n} from 'vue-i18n';
 const {t} = useI18n();
 const projectStore = useProjectStore();
 const {info} = useSnackbar();
-const tokenGrid = ref<HTMLElement | null>(null);
 
-const tokenHeaders = computed<DataTableHeader[]>(() => [
-  {
-    title: t('COL_ACTIONS'),
-    align: 'center',
-    filterable: true,
-    class: 'tableHeaderCell',
-    value: 'actions',
-    width: 120,
-    sortable: false,
-  },
-  {
-    title: t('TOKEN_NAME'),
-    align: 'start',
-    sortable: true,
-    class: 'tableHeaderCell',
-    value: 'company',
-    width: 160,
-  },
-  {
-    title: t('COL_DESCRIPTION'),
-    align: 'start',
-    sortable: true,
-    class: 'tableHeaderCell',
-    value: 'description',
-  },
-  {
-    title: t('COL_STATUS'),
-    align: 'start',
-    sortable: true,
-    class: 'tableHeaderCell',
-    value: 'status',
-    width: 160,
-  },
-  {
-    title: t('COL_CREATED'),
-    align: 'start',
-    sortable: true,
-    class: 'tableHeaderCell',
-    value: 'created',
-    width: 160,
-  },
-  {
-    title: t('COL_EXPIRY'),
-    align: 'start',
-    sortable: true,
-    class: 'tableHeaderCell',
-    value: 'expiry',
-    width: 160,
-  },
-]);
+const tokenGrid = ref<HTMLElement | null>(null);
 const tokens = ref<Token[]>([]);
 const dataAreLoaded = ref(false);
-const menu = ref(false);
 const selectedFilterStatus = ref<string[]>([]);
-const possibleStatus = ref<IDefaultSelectItem[]>([]);
 const create = ref(false);
 const update = ref(false);
 const del = ref(false);
@@ -93,6 +34,51 @@ const sortBy: SortItem[] = [{key: 'created', order: 'desc'}];
 const tokenRef = ref<Token>({} as Token);
 const renewed = ref(false);
 
+const tokenHeaders = computed((): DataTableHeader[] => [
+  {
+    title: t('COL_ACTIONS'),
+    align: 'center',
+    value: 'actions',
+    width: 120,
+    sortable: false,
+  },
+  {
+    title: t('TOKEN_NAME'),
+    align: 'start',
+    sortable: true,
+    value: 'company',
+    width: 160,
+  },
+  {
+    title: t('COL_DESCRIPTION'),
+    align: 'start',
+    sortable: true,
+    width: 180,
+    value: 'description',
+  },
+  {
+    title: t('COL_STATUS'),
+    align: 'start',
+    sortable: true,
+    value: 'status',
+    width: 160,
+  },
+  {
+    title: t('COL_CREATED'),
+    align: 'start',
+    sortable: true,
+    value: 'created',
+    width: 160,
+  },
+  {
+    title: t('COL_EXPIRY'),
+    align: 'start',
+    sortable: true,
+    value: 'expiry',
+    width: 160,
+  },
+]);
+
 const projectModel = computed(() => projectStore.currentProject!);
 const filteredList = computed(() => _.filter(tokens.value, filterOnStatus));
 
@@ -100,20 +86,19 @@ function filterOnStatus(item: Token): boolean {
   return selectedFilterStatus.value.length === 0 || _.includes(selectedFilterStatus.value, item.status);
 }
 
-function getPossibleStatus(): IDefaultSelectItem[] {
+const possibleStatus = computed((): DataTableHeaderFilterItems[] => {
   if (!tokens.value) {
     return [];
   }
-  return _.chain(tokens.value)
-    .uniqBy('status')
-    .map((item: Token) => {
-      return {
-        text: item.status,
-        value: item.status,
-      } as IDefaultSelectItem;
-    })
-    .value();
-}
+
+  const uniqueStatuses = [...new Set(tokens.value.map(({status}) => status))];
+
+  return uniqueStatuses.map((value: string) => {
+    return {
+      value,
+    } as DataTableHeaderFilterItems;
+  });
+});
 
 onMounted(async () => {
   await reload();
@@ -133,7 +118,6 @@ async function reload() {
   if (projectModel.value._key) {
     projectService.getTokens(projectModel.value._key).then((response) => {
       tokens.value = response;
-      possibleStatus.value = getPossibleStatus();
       dataAreLoaded.value = true;
     });
   }
@@ -232,67 +216,25 @@ const getActionButtons = (item: Token): TableActionButtonsProps['buttons'] => {
           :headers="tokenHeaders"
           :items="filteredList"
           :item-class="getCssClassForTableRow">
-          <template v-slot:item.created="{item}">
+          <template #[`header.status`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterStatus"
+                  :column="column"
+                  :label="t('COL_STATUS')"
+                  :allItems="possibleStatus">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
+          </template>
+          <template #[`item.created`]="{item}">
             <DDateCellWithTooltip :value="item.created" />
           </template>
-          <template v-slot:item.expiry="{item}">
+          <template #[`item.expiry`]="{item}">
             <DDateCellWithTooltip :value="item.expiry" />
           </template>
-          <template v-slot:header.status="{column, getSortIcon, toggleSort}">
-            <div class="v-data-table-header__content">
-              <span>{{ column.title }}</span>
-              <v-menu :close-on-content-click="false" v-model="menu">
-                <template v-slot:activator="{props}">
-                  <DIconButton
-                    :parentProps="props"
-                    icon="mdi-filter-variant"
-                    :hint="t('TT_SHOW_FILTER')"
-                    :color="selectedFilterStatus.length > 0 ? 'primary' : 'default'" />
-                </template>
-                <div class="bg-background" style="width: 280px">
-                  <v-row class="d-flex ma-1 mr-2 justify-end">
-                    <DIconButton icon="mdi-close" @clicked="menu = false" color="default" />
-                  </v-row>
-                  <v-select
-                    v-model="selectedFilterStatus"
-                    :items="possibleStatus"
-                    class="pa-2 mx-2 pb-4"
-                    :label="t('Lbl_filter_status')"
-                    clearable
-                    multiple
-                    item-title="text"
-                    item-value="value"
-                    variant="outlined"
-                    density="compact"
-                    menu
-                    transition="scale-transition"
-                    persistent-clear
-                    :list-props="{class: 'striped-filter-dd py-0'}">
-                    <template v-slot:item="{props}">
-                      <v-list-item v-bind="props" class="px-2 py-0">
-                        <template v-slot:prepend="{isSelected}">
-                          <v-checkbox hide-details :model-value="isSelected" />
-                        </template>
-                        <template v-slot:title="{title}">
-                          <span class="pFilterEntry"> {{ title }}</span>
-                        </template>
-                      </v-list-item>
-                    </template>
-                    <template v-slot:selection="{item, index}">
-                      <div v-if="index === 0" class="d-flex align-center">
-                        <span class="pFilterEntry">{{ item.title }}</span>
-                      </div>
-                      <span v-if="index === 1" class="pAdditionalFilter">
-                        +{{ selectedFilterStatus.length - 1 }} others
-                      </span>
-                    </template>
-                  </v-select>
-                </div>
-              </v-menu>
-              <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-            </div>
-          </template>
-          <template v-slot:item.actions="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
               :buttons="getActionButtons(item)"

--- a/frontend/libs/portal/components/projects/projectsDetail/TabProjectUserManagement.vue
+++ b/frontend/libs/portal/components/projects/projectsDetail/TabProjectUserManagement.vue
@@ -5,31 +5,23 @@
 <script setup lang="ts">
 // TODO: TabProjectUserManagement & TabProjectChildrenUserManagement have a lot of duplicated code. Refactor to a common component.
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import ConfirmationDialog from '@disclosure-portal/components/dialog/ConfirmationDialog.vue';
 import {ErrorDialogInterface} from '@disclosure-portal/components/dialog/DialogInterfaces';
-import ErrorDialog from '@disclosure-portal/components/dialog/ErrorDialog.vue';
-import NewUserDialog from '@disclosure-portal/components/dialog/NewUserDialog.vue';
 import DHTTPError from '@disclosure-portal/model/DHTTPError';
 import ErrorDialogConfig from '@disclosure-portal/model/ErrorDialogConfig';
-import {IDefaultSelectItem} from '@disclosure-portal/model/ISelectItem';
 import {ProjectUser, UserType} from '@disclosure-portal/model/Project';
 import projectService from '@disclosure-portal/services/projects';
-import {useAppStore} from '@disclosure-portal/stores/app';
 import {useProjectStore} from '@disclosure-portal/stores/project.store';
 import eventBus from '@disclosure-portal/utils/eventbus';
 import {getCssClassForTableRow} from '@disclosure-portal/utils/Table';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
-import DIconButton from '@shared/components/disco/DIconButton.vue';
-import TableActionButtons, {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
+import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
 import TableLayout from '@shared/layouts/TableLayout.vue';
-import {DataTableHeader, SortItem} from '@shared/types/table';
+import {DataTableHeader, DataTableHeaderFilterItems, SortItem} from '@shared/types/table';
 import _ from 'lodash';
 import {computed, onBeforeMount, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 
 const {t} = useI18n();
-const appStore = useAppStore();
 const projectStore = useProjectStore();
 const {info} = useSnackbar();
 
@@ -39,9 +31,7 @@ const confirmationDialogConfig = ref<IConfirmationDialogConfig>({} as IConfirmat
 
 const users = ref<ProjectUser[]>([]);
 const dataAreLoaded = ref(false);
-const menu = ref(false);
 const selectedFilterUserType = ref<string[]>([]);
-const possibleUserTypes = ref<IDefaultSelectItem[]>([]);
 const search = ref('');
 const userDialogMode = ref<'create' | 'edit'>('create');
 const editingUser = ref<ProjectUser>(new ProjectUser());
@@ -52,54 +42,47 @@ const errorDialog = ref<ErrorDialogInterface | null>(null);
 const sortItems = ref<SortItem[]>([{key: 'userType', order: 'asc'}]);
 
 const projectModel = computed(() => projectStore.currentProject!);
-const isLangEn = computed(() => appStore.appLanguage === 'en');
-const userHeaders = computed((): DataTableHeader[] => {
-  const res: DataTableHeader[] = [
-    {
-      title: t('COL_USER'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'userId',
-      width: 420,
-    },
-    {
-      title: t('COL_USER_TYPE'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'userType',
-      width: 160,
-      sortable: true,
-    },
-    {
-      title: t('COL_USER_ROLE'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'responsible',
-      width: isLangEn.value ? 160 : 180,
-    },
-    {
-      title: t('COL_USER_COMMENT'),
-      align: 'start',
-      sortable: true,
-      class: 'tableHeaderCell',
-      value: 'comment',
-    },
-  ];
-  if (projectModel.value.allowUserManagementUpdate || projectModel.value.allowUserManagementDelete) {
-    res.unshift({
-      title: t('COL_ACTIONS'),
-      align: 'center',
-      filterable: true,
-      class: 'tableHeaderCell',
-      value: 'actions',
-      width: 160,
-      sortable: false,
-    });
-  }
-  return res;
-});
+const userHeaders = computed((): DataTableHeader[] => [
+  ...(projectModel.value.allowUserManagementUpdate || projectModel.value.allowUserManagementDelete
+    ? [
+      {
+        title: t('COL_ACTIONS'),
+        align: 'center',
+        value: 'actions',
+        width: 160,
+        sortable: false,
+      } as DataTableHeader,
+    ]
+    : []),
+  {
+    title: t('COL_USER'),
+    align: 'start',
+    sortable: true,
+    value: 'userId',
+    width: 420,
+  },
+  {
+    title: t('COL_USER_TYPE'),
+    align: 'start',
+    value: 'userType',
+    width: 160,
+    sortable: true,
+  },
+  {
+    title: t('COL_USER_ROLE'),
+    align: 'start',
+    sortable: true,
+    value: 'responsible',
+    width: 180,
+  },
+  {
+    title: t('COL_USER_COMMENT'),
+    align: 'start',
+    sortable: true,
+    value: 'comment',
+    width: 180,
+  },
+]);
 
 const filteredList = computed(() => {
   return _.filter(users.value, filterOnType);
@@ -109,29 +92,25 @@ const filterOnType = (item: ProjectUser): boolean => {
   return selectedFilterUserType.value.length === 0 || selectedFilterUserType.value.includes(item.userType);
 };
 
-const getPossibleUserTypes = (): IDefaultSelectItem[] => {
+const possibleUserTypes = computed((): DataTableHeaderFilterItems[] => {
   if (!users.value) {
     return [];
   }
-  return _.chain(users.value)
-    .uniqBy('userType')
-    .map(
-      (item: ProjectUser) =>
-        ({
-          text: item.userType,
-          value: item.userType,
-        }) as IDefaultSelectItem,
-    )
-    .value();
-};
+
+  const uniqueUserTypes = [...new Set(users.value.map(({userType}) => userType))];
+
+  return uniqueUserTypes.map((value: string) => {
+    return {
+      value,
+    } as DataTableHeaderFilterItems;
+  });
+});
 
 const reload = async () => {
   dataAreLoaded.value = false;
   try {
     const response = await projectService.getUserManagement(projectModel.value._key);
     users.value = response.users;
-    possibleUserTypes.value = getPossibleUserTypes();
-    // await projectStore.fetchProjectByKey(projectModel.value._key);
   } finally {
     dataAreLoaded.value = true;
   }
@@ -267,7 +246,7 @@ const closeUserDialog = () => {
   userDialogRef.value?.close();
 };
 
-const getActionButtons = (item: ProjectUser): TableActionButtonsProps['buttons'] => {
+const actionButtons = computed((): TableActionButtonsProps['buttons'] => {
   const canModify = !projectModel.value.isDeprecated;
 
   return [
@@ -284,7 +263,7 @@ const getActionButtons = (item: ProjectUser): TableActionButtonsProps['buttons']
       show: projectModel.value.allowUserManagementDelete && canModify,
     },
   ];
-};
+});
 
 onBeforeMount(async () => {
   await reload();
@@ -327,73 +306,31 @@ onBeforeMount(async () => {
           :item-class="getCssClassForTableRow"
           :sort-by="sortItems"
           :custom-filter="customFilterTable">
-          <template v-slot:item.userId="{item}">
+          <template #[`header.userType`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterUserType"
+                  :column="column"
+                  :label="t('COL_USER_TYPE')"
+                  :allItems="possibleUserTypes">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
+          </template>
+          <template #[`item.userId`]="{item}">
             <span v-if="item.userProfile.user">
               {{ item.userProfile.lastname }}, {{ item.userProfile.forename }} ({{ item.userProfile.user }})
             </span>
             <span v-else>{{ item.userId }}</span>
           </template>
-          <template v-slot:item.responsible="{item}">
+          <template #[`item.responsible`]="{item}">
             <div v-if="item.responsible">{{ t('COL_USER_ROLE_RESPONSIBLE') }}</div>
           </template>
-          <template v-slot:header.userType="{column, getSortIcon, toggleSort}">
-            <div class="v-data-table-header__content">
-              <span>{{ column.title }}</span>
-              <v-menu :close-on-content-click="false" v-model="menu">
-                <template v-slot:activator="{props}">
-                  <DIconButton
-                    :parentProps="props"
-                    icon="mdi-filter-variant"
-                    :hint="t('TT_SHOW_FILTER')"
-                    :color="selectedFilterUserType.length > 0 ? 'primary' : 'default'" />
-                </template>
-                <div class="bg-background" style="width: 280px">
-                  <v-row class="d-flex ma-1 mr-2 justify-end">
-                    <DIconButton icon="mdi-close" @clicked="menu = false" color="default" />
-                  </v-row>
-                  <v-select
-                    v-model="selectedFilterUserType"
-                    :items="possibleUserTypes"
-                    class="pa-2 mx-2 pb-4"
-                    :label="t('Lbl_filter_userType')"
-                    clearable
-                    multiple
-                    item-title="text"
-                    item-value="value"
-                    variant="outlined"
-                    density="compact"
-                    menu
-                    transition="scale-transition"
-                    persistent-clear
-                    :list-props="{class: 'striped-filter-dd py-0'}">
-                    <template v-slot:item="{props}">
-                      <v-list-item v-bind="props" class="px-2 py-0">
-                        <template v-slot:prepend="{isSelected}">
-                          <v-checkbox hide-details :model-value="isSelected" />
-                        </template>
-                        <template v-slot:title="{title}">
-                          <span class="pStatusFilterEntry"> {{ title }}</span>
-                        </template>
-                      </v-list-item>
-                    </template>
-                    <template v-slot:selection="{item, index}">
-                      <div v-if="index === 0" class="d-flex align-center">
-                        <span class="pStatusFilterEntry">{{ item.title }}</span>
-                      </div>
-                      <span v-if="index === 1" class="pAdditionalFilter">
-                        +{{ selectedFilterUserType.length - 1 }} others
-                      </span>
-                    </template>
-                  </v-select>
-                </div>
-              </v-menu>
-              <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-            </div>
-          </template>
-          <template v-slot:item.actions="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
-              :buttons="getActionButtons(item)"
+              :buttons="actionButtons"
               @edit="showEditUserDialog(item)"
               @remove="showDeleteUserDialog(item)" />
           </template>

--- a/frontend/libs/portal/stores/project.store.ts
+++ b/frontend/libs/portal/stores/project.store.ts
@@ -42,6 +42,7 @@ export const useProjectStore = defineStore('project', () => {
       return {
         text: t('STATUS_' + status),
         textColor: projectsUtils.getTextStatusColor(status),
+        textBold: true,
         value: key,
       };
     }),

--- a/frontend/libs/portal/utils/Tools.ts
+++ b/frontend/libs/portal/utils/Tools.ts
@@ -14,6 +14,11 @@ export function getColorRGB(colorVariable: string) {
   return 'rgb(' + getComputedStyle(document.documentElement).getPropertyValue(colorVariable).trim() + ')';
 }
 
+export function capitalizeFirstLetter(text: string) {
+  if (!text) return '';
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 export function truncateText(text: string, maxLength: number) {
   if (text.length > maxLength) {
     return text.substring(0, maxLength) + '...';

--- a/frontend/libs/portal/utils/policyRules.ts
+++ b/frontend/libs/portal/utils/policyRules.ts
@@ -1,11 +1,11 @@
 import {capitalizeFirstLetter} from '@disclosure-portal/utils/Tools';
 
 const getTextStatusColor = (itemStatus: string) => {
-  const color = !itemStatus ? 'New' : capitalizeFirstLetter(itemStatus);
-  return `rgb(var(--v-theme-project${color}))`;
+  const color = capitalizeFirstLetter(itemStatus);
+  return `rgb(var(--v-theme-pr${color}))`;
 };
 
-export const useProjectUtils = () => {
+export const usePolicyRulesUtils = () => {
   return {
     getTextStatusColor,
   };

--- a/frontend/libs/portal/views/licenses/Licenses.vue
+++ b/frontend/libs/portal/views/licenses/Licenses.vue
@@ -24,7 +24,6 @@ import {SearchOptions} from '@disclosure-portal/utils/Table';
 import useViewTools, {getIconColorOfLevel, getIconOfLevel, openUrl} from '@disclosure-portal/utils/View';
 import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
-import {useTableActionSlider} from '@shared/composables/useTableActionSlider';
 import {useBreadcrumbsStore} from '@shared/stores/breadcrumbs.store';
 import {useHeaderSettingsStore} from '@shared/stores/headerSettings.store';
 import {DataTableHeader, DataTableHeaderFilterItems, DataTableItem} from '@shared/types/table';
@@ -48,7 +47,6 @@ const snackbar = useSnackbar();
 const route = useRoute();
 const userStore = useUserStore();
 const viewTools = useViewTools();
-const {sliderWidth} = useTableActionSlider();
 
 const gridName = 'License';
 const headerSettingsStore = useHeaderSettingsStore();
@@ -107,73 +105,73 @@ const options = computed(
 const possibleIsLicenseChart = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleCharts)
-        .map(([k, count]) => ({
-          text: k === 'true' ? t('TABLE_LICENSE_CHART_STATUS_IS') : t('TABLE_LICENSE_CHART_STATUS_IS_NOT'),
-          value: k,
-          chip: String(count),
-        }))
-        .sort()
+      .map(([k, count]) => ({
+        text: k === 'true' ? t('TABLE_LICENSE_CHART_STATUS_IS') : t('TABLE_LICENSE_CHART_STATUS_IS_NOT'),
+        value: k,
+        chip: String(count),
+      }))
+      .sort()
     : [],
 );
 
 const possibleSources = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleSources).map(([k, count]) => ({
-        text: k,
-        value: k,
-        chip: String(count),
-      }))
+      text: k,
+      value: k,
+      chip: String(count),
+    }))
     : [],
 );
 
 const possibleFamilies = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? Object.entries(metaData.value.possibleFamilies)
-        .sort((a, b) => compareFamily(a[0], b[0]))
-        .map(([k, count]) => ({
-          text: getI18NTextOfPrefixKey('LIC_FAMILY_', k),
-          value: k.length === 0 ? 'not declared' : k,
-          chip: String(count),
-        }))
-    : [],
-);
-
-const possibleApproval = computed((): DataTableHeaderFilterItems[] =>
-  metaData.value
-    ? Object.entries(metaData.value.possibleApproval)
-        .sort(
-          ([keyA], [keyB]) => getLicenseApprovalTypeKeys().indexOf(keyA) - getLicenseApprovalTypeKeys().indexOf(keyB),
-        )
-        .map(([k, count]) => ({
-          text: getI18NTextOfPrefixKey('LT_APP_', k),
-          value: k.length === 0 ? 'not set' : k,
-          chip: String(count),
-        }))
-    : [],
-);
-
-const possibleType = computed((): DataTableHeaderFilterItems[] =>
-  metaData.value
-    ? Object.entries(metaData.value.possibleType).map(([k, count]) => ({
-        text: getI18NTextOfPrefixKey('LT_', k),
+      .sort((a, b) => compareFamily(a[0], b[0]))
+      .map(([k, count]) => ({
+        text: getI18NTextOfPrefixKey('LIC_FAMILY_', k),
         value: k.length === 0 ? 'not declared' : k,
         chip: String(count),
       }))
     : [],
 );
 
+const possibleApproval = computed((): DataTableHeaderFilterItems[] =>
+  metaData.value
+    ? Object.entries(metaData.value.possibleApproval)
+      .sort(
+        ([keyA], [keyB]) => getLicenseApprovalTypeKeys().indexOf(keyA) - getLicenseApprovalTypeKeys().indexOf(keyB),
+      )
+      .map(([k, count]) => ({
+        text: getI18NTextOfPrefixKey('LT_APP_', k),
+        value: k.length === 0 ? 'not set' : k,
+        chip: String(count),
+      }))
+    : [],
+);
+
+const possibleType = computed((): DataTableHeaderFilterItems[] =>
+  metaData.value
+    ? Object.entries(metaData.value.possibleType).map(([k, count]) => ({
+      text: getI18NTextOfPrefixKey('LT_', k),
+      value: k.length === 0 ? 'not declared' : k,
+      chip: String(count),
+    }))
+    : [],
+);
+
 const possibleClassifications = computed((): DataTableHeaderFilterItems[] =>
   metaData.value
     ? metaData.value.possibleClassifications.map(({classification, count}: ClassificationWithCount) => {
-        const value = viewTools.getNameForLanguage(classification) ? classification.name : '';
-        return {
-          text: viewTools.getNameForLanguage(classification) || t('NO_CLASSIFICATIONS'),
-          value: value,
-          icon: getIconOfLevel(getWarnLevel(value).toUpperCase()),
-          iconColor: getIconColorOfLevel(getWarnLevel(value)),
-          chip: String(count),
-        };
-      })
+      const value = viewTools.getNameForLanguage(classification) ? classification.name : '';
+      return {
+        text: viewTools.getNameForLanguage(classification) || t('NO_CLASSIFICATIONS'),
+        value: value,
+        icon: getIconOfLevel(getWarnLevel(value).toUpperCase()),
+        iconColor: getIconColorOfLevel(getWarnLevel(value)),
+        chip: String(count),
+      };
+    })
     : [],
 );
 
@@ -347,13 +345,13 @@ const allowActions = computed(() => RightsUtils.hasLicenseAccess() || RightsUtil
 const headers = computed((): DataTableHeader[] => [
   ...(allowActions.value
     ? [
-        {
-          title: 'COL_ACTIONS',
-          align: 'start',
-          width: sliderWidth.value,
-          value: 'actions',
-        } as DataTableHeader,
-      ]
+      {
+        title: 'COL_ACTIONS',
+        align: 'center',
+        width: 120,
+        value: 'actions',
+      } as DataTableHeader,
+    ]
     : []),
   {
     title: 'COL_LICENSE_CHART_STATUS',
@@ -648,7 +646,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <TableLayout data-testid="licenses" @mouseleave="headerExpands">
+  <TableLayout data-testid="licenses">
     <template #description>
       <div class="d-flex align-center ga-3 flex-row">
         <h1 class="text-h5">{{ t('Licenses') }}</h1>
@@ -719,7 +717,7 @@ onMounted(async () => {
         return-object></v-select>
     </template>
     <template #table>
-      <div ref="dataGridLicenses" class="table-wrapper fill-height action-slider-table">
+      <div ref="dataGridLicenses" class="table-wrapper fill-height">
         <v-data-table-server
           :headers="filteredHeaders"
           fixed-header
@@ -824,7 +822,7 @@ onMounted(async () => {
               <v-icon
                 :class="item.meta.prevalentClassificationLevel.toUpperCase() === 'WARNING' ? 'mr-1' : 'mr-2'"
                 :color="getIconColorOfLevel(item.meta.prevalentClassificationLevel)"
-                >{{ getIconOfLevel(item.meta.prevalentClassificationLevel) }}
+              >{{ getIconOfLevel(item.meta.prevalentClassificationLevel) }}
               </v-icon>
               <Tooltip location="bottom">
                 {{ t('TT_OPEN_CLASSIFICATIONS', {license: item.name}) }}
@@ -857,7 +855,7 @@ onMounted(async () => {
           </template>
           <template v-if="allowActions" #[`item.actions`]="{item}">
             <TableActionButtons
-              variant="slider"
+              variant="compact"
               :buttons="getActionButtons(item)"
               @edit="editLicense(item)"
               @duplicate="duplicateLicense(item)"

--- a/frontend/libs/portal/views/policies/PolicyRules.vue
+++ b/frontend/libs/portal/views/policies/PolicyRules.vue
@@ -4,9 +4,6 @@
 
 <script setup lang="ts">
 import {ConfirmationType, IConfirmationDialogConfig} from '@disclosure-portal/components/dialog/ConfirmationDialog';
-import ConfirmationDialog from '@disclosure-portal/components/dialog/ConfirmationDialog.vue';
-import NewPolicyRuleDialog from '@disclosure-portal/components/dialog/NewPolicyRuleDialog.vue';
-import {IDefaultSelectItem} from '@disclosure-portal/model/ISelectItem';
 import Label from '@disclosure-portal/model/Label';
 import PolicyRule from '@disclosure-portal/model/PolicyRule';
 import AdminService from '@disclosure-portal/services/admin';
@@ -16,23 +13,21 @@ import {RightsUtils} from '@disclosure-portal/utils/Rights';
 import {formatDateAndTime, getCssClassForTableRow} from '@disclosure-portal/utils/Table';
 import {openUrl} from '@disclosure-portal/utils/url';
 import {getStrWithMaxLength} from '@disclosure-portal/utils/View';
-import DCActionButton from '@shared/components/disco/DCActionButton.vue';
-import DDateCellWithTooltip from '@shared/components/disco/DDateCellWithTooltip.vue';
-import DIconButton from '@shared/components/disco/DIconButton.vue';
 import {TableActionButtonsProps} from '@shared/components/TableActionButtons.vue';
 import useSnackbar from '@shared/composables/useSnackbar';
-import TableLayout from '@shared/layouts/TableLayout.vue';
 import {useBreadcrumbsStore} from '@shared/stores/breadcrumbs.store';
-import {DataTableHeader, DataTableItem, SortItem} from '@shared/types/table';
+import {DataTableHeader, DataTableHeaderFilterItems, DataTableItem, SortItem} from '@shared/types/table';
 import dayjs from 'dayjs';
 import {computed, onMounted, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {useRouter} from 'vue-router';
+import {usePolicyRulesUtils} from '@disclosure-portal/utils/policyRules';
 
 const {t} = useI18n();
 const breadcrumbs = useBreadcrumbsStore();
 const {info} = useSnackbar();
 const router = useRouter();
+const policyRulesUtils = usePolicyRulesUtils();
 
 const confirmConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDialogConfig);
 const confirmVisible = ref(false);
@@ -40,22 +35,27 @@ const confirmDeprConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDial
 const confirmDeprVisible = ref(false);
 const confirmCopyConfig = ref<IConfirmationDialogConfig>({} as IConfirmationDialogConfig);
 const confirmCopyVisible = ref(false);
-const possibleStatus = ref<IDefaultSelectItem[]>([
+const possibleStatus = ref<DataTableHeaderFilterItems[]>([
   {
     text: t('PR_STATUS_ACTIVE'),
+    textColor: policyRulesUtils.getTextStatusColor('active'),
+    textBold: true,
     value: 'active',
   },
   {
     text: t('PR_STATUS_INACTIVE'),
+    textColor: policyRulesUtils.getTextStatusColor('inactive'),
+    textBold: true,
     value: 'inactive',
   },
   {
     text: t('PR_STATUS_DEPRECATED'),
+    textColor: policyRulesUtils.getTextStatusColor('deprecated'),
+    textBold: true,
     value: 'deprecated',
   },
 ]);
-const menu = ref(false);
-const selectedFilterStatus = ref<string[]>(['active', 'inactive']);
+const selectedFilterStatus = ref<string[]>([]);
 const items = ref<PolicyRule[]>([]);
 const search = ref('');
 const isPolicyManager = ref(false);
@@ -225,99 +225,78 @@ onMounted(async () => {
   await reload();
 });
 
-const headers = computed(() => {
-  return [
-    {
-      title: t('COL_ACTIONS'),
-      align: 'center',
-      filterable: true,
-      class: 'tableHeaderCell',
-      value: 'actions',
-      width: 80,
-      sortable: false,
-    },
-    {
-      title: t('COL_STATUS'),
-      align: 'start',
-      class: 'tableHeaderCell',
-      value: 'Status',
-      width: 110,
-      sortable: true,
-    },
-    {
-      title: t('COL_NAME'),
-      align: 'start',
-      filterable: true,
-      class: 'tableHeaderCell',
-      value: 'Name',
-      width: 300,
-      sortable: true,
-    },
-    {
-      title: t('DESCRIPTION'),
-      align: 'start',
-      filterable: false,
-      class: 'tableHeaderCell',
-      value: 'Description',
-      width: 350,
-      sortable: false,
-    },
-    {
-      title: t('TOTAL'),
-      align: 'center',
-      filterable: false,
-      class: 'tableHeaderCell',
-      value: 'Total',
-      width: 75,
-      sortable: false,
-    },
-    {
-      title: t('ALLOWED'),
-      align: 'center',
-      filterable: false,
-      class: 'tableHeaderCell',
-      value: 'Allowed',
-      width: 75,
-      sortable: false,
-    },
-    {
-      title: t('WARNED'),
-      align: 'center',
-      filterable: false,
-      class: 'tableHeaderCell',
-      value: 'Warned',
-      width: 75,
-      sortable: false,
-    },
-    {
-      title: t('DENIED'),
-      align: 'center',
-      filterable: false,
-      class: 'tableHeaderCell',
-      value: 'Denied',
-      width: 75,
-      sortable: false,
-    },
-    {
-      title: t('CREATED'),
-      align: 'center',
-      filterable: true,
-      class: 'tableHeaderCell',
-      value: 'created',
-      width: 108,
-      sortable: true,
-    },
-    {
-      title: t('UPDATED'),
-      align: 'center',
-      filterable: true,
-      class: 'tableHeaderCell',
-      value: 'updated',
-      width: 108,
-      sortable: true,
-    },
-  ] as DataTableHeader[];
-});
+const headers = computed((): DataTableHeader[] => [
+  {
+    title: t('COL_ACTIONS'),
+    align: 'center',
+    value: 'actions',
+    width: 80,
+    sortable: false,
+  },
+  {
+    title: t('COL_STATUS'),
+    align: 'start',
+    value: 'Status',
+    width: 110,
+    sortable: true,
+  },
+  {
+    title: t('COL_NAME'),
+    align: 'start',
+    value: 'Name',
+    width: 300,
+    sortable: true,
+  },
+  {
+    title: t('DESCRIPTION'),
+    align: 'start',
+    value: 'Description',
+    width: 350,
+    sortable: false,
+  },
+  {
+    title: t('TOTAL'),
+    align: 'center',
+    value: 'Total',
+    width: 75,
+    sortable: false,
+  },
+  {
+    title: t('ALLOWED'),
+    align: 'center',
+    value: 'Allowed',
+    width: 75,
+    sortable: false,
+  },
+  {
+    title: t('WARNED'),
+    align: 'center',
+    value: 'Warned',
+    width: 75,
+    sortable: false,
+  },
+  {
+    title: t('DENIED'),
+    align: 'center',
+    value: 'Denied',
+    width: 75,
+    sortable: false,
+  },
+  {
+    title: t('CREATED'),
+    align: 'center',
+    value: 'created',
+    width: 108,
+    sortable: true,
+  },
+  {
+    title: t('UPDATED'),
+    align: 'center',
+    value: 'updated',
+    width: 108,
+    sortable: true,
+  },
+]);
 </script>
 
 <template>
@@ -352,7 +331,7 @@ const headers = computed(() => {
         hide-details></v-text-field>
     </template>
     <template #table>
-      <div ref="tableGridPolicyRules" class="fill-height">
+      <div ref="tableGridPolicyRules" class="fill-height action-slider-table">
         <v-data-table
           density="compact"
           class="striped-table fill-height"
@@ -365,92 +344,50 @@ const headers = computed(() => {
           :items-per-page="-1"
           :search="search"
           :sort-by="sortItems">
-          <template v-slot:[`header.Status`]="{column, getSortIcon, toggleSort}">
-            <div class="v-data-table-header__content">
-              <span>{{ column.title }}</span>
-              <v-menu offset-y :close-on-content-click="false" v-model="menu">
-                <template v-slot:activator="{props}">
-                  <DIconButton
-                    :parentProps="props"
-                    icon="mdi-filter-variant"
-                    :hint="t('TT_SHOW_FILTER')"
-                    :color="selectedFilterStatus && selectedFilterStatus.length > 0 ? 'primary' : 'secondary'" />
-                </template>
-                <div style="width: 320px" class="bg-background">
-                  <v-card>
-                    <v-row class="d-flex ma-1 mr-2 justify-end">
-                      <DCloseButton @click="menu = false" />
-                    </v-row>
-
-                    <v-select
-                      variant="outlined"
-                      v-model="selectedFilterStatus"
-                      density="compact"
-                      class="pa-2 mx-2"
-                      autofocus
-                      clearable
-                      :items="possibleStatus"
-                      :label="t('lbl_filter_on_status')"
-                      hide-details
-                      item-title="text"
-                      item-value="value"
-                      multiple
-                      menu
-                      transition="scale-transition"
-                      persistent-clear
-                      :list-props="{class: 'striped-filter-dd py-0'}">
-                      <template v-slot:item="{props, item}">
-                        <v-list-item v-bind="props" :title="undefined" class="px-2 py-0">
-                          <template v-slot:prepend="{isSelected}">
-                            <v-checkbox hide-details :model-value="isSelected" />
-                          </template>
-                          <span :class="'prStatus' + item.value + ' prStatusFilter'">{{ item.title }}</span>
-                        </v-list-item>
-                      </template>
-                      <template v-slot:selection="{item, index}">
-                        <div v-if="index === 0" class="d-flex align-center">
-                          <span :class="'prStatus' + item.value + ' prStatusFilter'">{{ item.title }}</span>
-                        </div>
-                        <span v-if="index === 1" class="pAdditionalFilter">
-                          +{{ selectedFilterStatus.length - 1 }} others
-                        </span>
-                      </template>
-                    </v-select>
-                  </v-card>
-                </div>
-              </v-menu>
-              <v-icon class="v-data-table-header__sort-icon" :icon="getSortIcon(column)" @click="toggleSort(column)" />
-            </div>
+          <template #[`header.Status`]="{column, getSortIcon, toggleSort}">
+            <GridFilterHeader :column="column" :getSortIcon="getSortIcon" :toggleSort="toggleSort">
+              <template #filter>
+                <GridHeaderFilterIcon
+                  v-model="selectedFilterStatus"
+                  :column="column"
+                  :label="t('COL_STATUS')"
+                  :initial-selected="['active', 'inactive']"
+                  :allItems="possibleStatus">
+                </GridHeaderFilterIcon>
+              </template>
+            </GridFilterHeader>
           </template>
-          <template v-slot:[`item.Status`]="{item}">
-            <span :class="'prStatus' + item.Status">{{ t('PR_STATUS_' + item.Status.toUpperCase()) }}</span>
+          <template #[`item.Status`]="{item}">
+            <span class="font-bold" :style="{color: policyRulesUtils.getTextStatusColor(item.Status)}">{{
+                t('PR_STATUS_' + item.Status.toUpperCase())
+              }}</span>
           </template>
-          <template v-slot:item.Allowed="{item}">
+          <template #[`item.Allowed`]="{item}">
             {{ item.ComponentsAllow.length }}
           </template>
-          <template v-slot:item.Warned="{item}">
+          <template #[`item.Warned`]="{item}">
             {{ item.ComponentsWarn.length }}
           </template>
-          <template v-slot:item.Denied="{item}">
+          <template #[`item.Denied`]="{item}">
             {{ item.ComponentsDeny.length }}
           </template>
-          <template v-slot:item.Total="{item}">
+          <template #[`item.Total`]="{item}">
             {{ item.ComponentsAllow.length + item.ComponentsDeny.length + item.ComponentsWarn.length }}
           </template>
-          <template v-slot:item.Description="{item}">
+          <template #[`item.Description`]="{item}">
             <v-tooltip :text="item.Description" width="320" location="bottom" content-class="dpTooltip">
-              <template v-slot:activator="{props}"
-                ><span v-bind="props">{{ getStrWithMaxLength(95, item.Description) }}</span>
+              <template #activator="{props}"
+              ><span v-bind="props">{{ getStrWithMaxLength(95, item.Description) }}</span>
               </template></v-tooltip
             >
           </template>
-          <template v-slot:item.updated="{item}">
+          <template #[`item.updated`]="{item}">
             <DDateCellWithTooltip :value="item.updated" />
           </template>
-          <template v-slot:item.created="{item}">
+          <template #[`item.created`]="{item}">
             <DDateCellWithTooltip :value="item.created" />
           </template>
-          <template v-slot:item.actions="{item}">
+          <template #[`item.actions`]="{item}">
             <TableActionButtons
               variant="compact"
               :buttons="getActionButtons(item)"

--- a/frontend/libs/portal/views/projects/ProjectsDetail.vue
+++ b/frontend/libs/portal/views/projects/ProjectsDetail.vue
@@ -149,7 +149,7 @@ onUnmounted(() => {
       <span class="text-h5 inline-block" :class="{statusDeprecated: currentProject.status === 'deprecated'}">
         {{ currentProject.isGroup ? t('GROUP') : t('PROJECT') }} <q>{{ currentProject.name }}</q>
       </span>
-      <span :style="{color: projectsUtils.getTextStatusColor(currentProject.status)}">
+      <span class="font-bold" :style="{color: projectsUtils.getTextStatusColor(currentProject.status)}">
         {{ t('STATUS_' + (!currentProject.status ? 'new' : currentProject.status)) }}
       </span>
       <DIconButton
@@ -261,16 +261,17 @@ onUnmounted(() => {
         </v-card>
       </v-col>
     </v-row>
-    <DFormDialog v-model:dialog="projectSubscriptionsDialogVisible" v-model="projectSubscriptionsDialogOpen" persistent>
-      <ProjectSubscriptionsDialog
-        :title="t('TITLE_PROJECT_SUBSCRIPTIONS')"
-        :confirm-text="t('NP_DIALOG_BTN_EDIT')"
-        :item="currentProject.subscriptions"
-        @confirm="saveProjectSubscriptions"
-        @close="projectSubscriptionsDialogOpen = false">
-      </ProjectSubscriptionsDialog>
-    </DFormDialog>
   </v-container>
+
+  <DFormDialog v-model:dialog="projectSubscriptionsDialogVisible" v-model="projectSubscriptionsDialogOpen" persistent>
+    <ProjectSubscriptionsDialog
+      :title="t('TITLE_PROJECT_SUBSCRIPTIONS')"
+      :confirm-text="t('NP_DIALOG_BTN_EDIT')"
+      :item="currentProject!.subscriptions"
+      @confirm="saveProjectSubscriptions"
+      @close="projectSubscriptionsDialogOpen = false">
+    </ProjectSubscriptionsDialog>
+  </DFormDialog>
 </template>
 
 <style scoped lang="scss">

--- a/frontend/libs/shared/layouts/GridHeaderMenu.vue
+++ b/frontend/libs/shared/layouts/GridHeaderMenu.vue
@@ -68,8 +68,8 @@ const showMenu = ref(false);
                 <span
                   :style="{color: item.raw?.textColor || 'inherit'}"
                   class="text-sm"
-                  :class="{'ml-1': item.raw?.icon}"
-                  >{{ item.raw?.text || item.raw.value }}</span
+                  :class="{'ml-1': item.raw?.icon, 'font-bold': item.raw?.textBold}"
+                >{{ item.raw?.text || item.raw.value }}</span
                 >
                 <v-chip
                   v-if="item.raw?.chip"
@@ -88,8 +88,8 @@ const showMenu = ref(false);
                   v-if="index === 0"
                   :style="{color: item.raw?.textColor || 'inherit'}"
                   class="text-sm"
-                  :class="{'ml-1': item.raw?.icon}"
-                  >{{ item.raw?.text || item.raw.value }}</span
+                  :class="{'ml-1': item.raw?.icon, 'font-bold': item.raw?.textBold}"
+                >{{ item.raw?.text || item.raw.value }}</span
                 >
                 <v-chip
                   v-if="item.raw?.chip"

--- a/frontend/libs/shared/types/table.d.ts
+++ b/frontend/libs/shared/types/table.d.ts
@@ -52,6 +52,7 @@ export type DataTableHeader = {
 export type DataTableHeaderFilterItems = {
   text?: string;
   textColor?: string;
+  textBold?: boolean;
   value: string;
   icon?: string;
   iconColor?: string;


### PR DESCRIPTION
- Refactored Filters
- Refactored colors for state of projects
- Added ability to have a text bold in possible filter-items
- Refactored widths for better visibility on small and large screens
- Deleted component imports
- Changed v-slot: to shorthand #
- Changed v-slot:item.property to #[`item.property`]