### PR TITLE
chore: increase retry count for keycloak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
         ]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 15
   server:
     build: backend
     depends_on:


### PR DESCRIPTION
Increase the health check retry count for keycloak to support machines with low resources, such as Raspberry PI. With only 3 retries, the docker-compose stack did not come up.