### PR TITLE
feat: implement two-column layout for license decision dialog

### DIFF
--- a/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
+++ b/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
@@ -241,88 +241,110 @@ defineExpose({open});
 </script>
 
 <template>
-  <v-dialog v-model="isVisible" width="650" persistent>
+  <v-dialog v-model="isVisible" width="1200" persistent>
     <DialogLayout :config="dialogConfig" @primary-action="doDialogAction" @secondary-action="close" @close="close">
       <v-form ref="form" @submit.prevent="doDialogAction">
         <Stack class="gap-4">
-          <Stack direction="row" align="center">
-            <v-icon class="mr-2">mdi-information-outline</v-icon>
-            <span>{{ t('LICENSE_RULE_APPLIED_LATER_INFO') }}</span>
+          <Stack direction="row" class="items-start gap-4">
+            <Stack class="flex-1 gap-4 self-start">
+              <v-text-field
+                autocomplete="off"
+                :model-value="selectedComponentStr"
+                disabled
+                variant="outlined"
+                density="compact"
+                hide-details
+                :label="t('RELATED_COMPONENT')" />
+              <v-textarea
+                auto-grow
+                rows="1"
+                variant="outlined"
+                density="compact"
+                disabled
+                :label="t('LICENSE_EXPRESSION')"
+                :model-value="selectedComponent?.licenseExpression"
+                hide-details />
+              <v-select
+                v-model="selectedLicense"
+                clearable
+                :label="t('LICENSE_DECISION')"
+                :disabled="!selectedComponent"
+                :items="licenses"
+                return-object
+                item-title="name"
+                :loading="licensesLoading"
+                variant="outlined"
+                density="compact"
+                hide-details
+                required
+                :rules="licenseDecisionRules">
+                <template #item="{item, props}">
+                  <v-list-item v-bind="props" title="">
+                    <v-chip
+                      v-if="item.raw.isRecommended"
+                      variant="outlined"
+                      label
+                      size="x-small"
+                      class="mr-1 font-bold">
+                      {{ t('RECOMMENDED') }}
+                    </v-chip>
+                    <v-icon size="small" :color="item.raw.iconColor">
+                      {{ item.raw.icon }}
+                    </v-icon>
+                    <span class="d-subtitle-2 ml-2">{{ item.raw.name }}</span>
+                    <span class="d-text d-secondary-text">&nbsp;({{ item.raw.id }})</span>
+                  </v-list-item>
+                </template>
+                <template #selection="{item}">
+                  <div class="d-inline">
+                    <v-chip
+                      v-if="item.raw.isRecommended"
+                      variant="outlined"
+                      label
+                      size="x-small"
+                      class="mr-1 font-bold">
+                      {{ t('RECOMMENDED') }}
+                    </v-chip>
+                    <v-icon size="small" :color="item.raw.iconColor">
+                      {{ item.raw.icon }}
+                    </v-icon>
+                    <span class="d-subtitle-2 ml-2">{{ item.raw.name }}</span>
+                    <span class="d-text d-secondary-text">&nbsp;({{ item.raw.id }})</span>
+                  </div>
+                </template>
+              </v-select>
+              <v-textarea
+                v-model="comment"
+                variant="outlined"
+                density="compact"
+                :label="t('LICENSE_RULE_COMMENT')"
+                hide-details="auto"
+                :rules="commentRules" />
+            </Stack>
+            <v-divider vertical class="mx-5" />
+            <Stack class="flex-1 gap-4 self-start">
+              <Stack direction="row" align="center">
+                <span class="text-h6">{{ t('IMPORTANT_INFO_TEXT') }}</span>
+              </Stack>
+              <Stack direction="row" align="center">
+                <v-icon class="mr-2" color="brand">mdi-arrow-right</v-icon>
+                <span>{{ t('LICENSE_RULE_APPLIED_LATER_INFO') }}</span>
+              </Stack>
+              <Stack v-if="licenseRecommendedMsg" direction="row" align="center">
+                <v-icon class="mr-2" color="brand">mdi-arrow-right</v-icon>
+                <span>{{ translatedLicenseRecommendedMsg }}</span>
+              </Stack>
+              <Stack v-if="selectedLicense?.policyType === 'noassertion'" direction="row" align="center">
+                <v-icon class="mr-2" color="error">mdi-arrow-right</v-icon>
+                <span>{{ t('UNASSERTED_LICENSES_MSG', {license: selectedLicense?.id}) }}</span>
+              </Stack>
+              <v-checkbox
+                v-model="verification"
+                color="primary"
+                :label="t('LICENSE_RULE_VERIFICATION_NOTE_TEXT')"
+                hide-details />
+            </Stack>
           </Stack>
-          <v-text-field
-            autocomplete="off"
-            :model-value="selectedComponentStr"
-            disabled
-            variant="outlined"
-            density="compact"
-            hide-details
-            :label="t('RELATED_COMPONENT')" />
-          <v-textarea
-            auto-grow
-            rows="1"
-            variant="outlined"
-            density="compact"
-            disabled
-            :label="t('LICENSE_EXPRESSION')"
-            :model-value="selectedComponent?.licenseExpression"
-            hide-details />
-          <v-alert v-if="licenseRecommendedMsg" density="compact" variant="outlined" type="info">
-            {{ translatedLicenseRecommendedMsg }}
-          </v-alert>
-          <v-alert
-            v-if="selectedLicense?.policyType === 'noassertion'"
-            density="compact"
-            variant="outlined"
-            type="warning">
-            {{ t('UNASSERTED_LICENSES_MSG', {license: selectedLicense?.id}) }}
-          </v-alert>
-          <v-select
-            v-model="selectedLicense"
-            clearable
-            :label="t('LICENSE_DECISION')"
-            :disabled="!selectedComponent"
-            :items="licenses"
-            return-object
-            item-title="name"
-            :loading="licensesLoading"
-            variant="outlined"
-            density="compact"
-            hide-details
-            required
-            :rules="licenseDecisionRules">
-            <template #item="{item, props}">
-              <v-list-item v-bind="props" title="">
-                <v-chip v-if="item.raw.isRecommended" variant="outlined" label size="x-small" class="mr-1 font-bold">
-                  {{ t('RECOMMENDED') }}
-                </v-chip>
-                <v-icon size="small" :color="item.raw.iconColor">
-                  {{ item.raw.icon }}
-                </v-icon>
-                <span class="d-subtitle-2 ml-2">{{ item.raw.name }}</span>
-                <span class="d-text d-secondary-text">&nbsp;({{ item.raw.id }})</span>
-              </v-list-item>
-            </template>
-            <template #selection="{item}">
-              <div class="d-inline">
-                <v-chip v-if="item.raw.isRecommended" variant="outlined" label size="x-small" class="mr-1 font-bold">
-                  {{ t('RECOMMENDED') }}
-                </v-chip>
-                <v-icon size="small" :color="item.raw.iconColor">
-                  {{ item.raw.icon }}
-                </v-icon>
-                <span class="d-subtitle-2 ml-2">{{ item.raw.name }}</span>
-                <span class="d-text d-secondary-text">&nbsp;({{ item.raw.id }})</span>
-              </div>
-            </template>
-          </v-select>
-          <v-textarea
-            v-model="comment"
-            variant="outlined"
-            density="compact"
-            :label="t('LICENSE_RULE_COMMENT')"
-            hide-details="auto"
-            :rules="commentRules" />
-          <v-checkbox v-model="verification" :label="t('LICENSE_RULE_VERIFICATION_NOTE_TEXT')" hide-details />
         </Stack>
       </v-form>
     </DialogLayout>

--- a/frontend/libs/portal/i18n/locales/de.json
+++ b/frontend/libs/portal/i18n/locales/de.json
@@ -2090,5 +2090,6 @@
   "DENIED_LICENSES_MSG": "Für diese Komponente ist keine akzeptable Lizenzoption aufgeführt. Bitte prüfe, ob weitere Lizenzierungsoptionen verfügbar sind, oder ersetze die Komponente.",
   "EQUAL_WEIGHT_LICENSES_MSG": "Keine Empfehlung möglich, da Lizenzbewertung gleich ist.",
   "UNASSERTED_LICENSES_MSG": "Die Lizenz \"{license}\" hat den Status „nicht zugeordnet“ und wurde daher nicht in diesen Vergleich einbezogen. Bitte prüfe die Lizenzinformationen und aktualisiere die SBOM, wenn du diese Lizenz berücksichtigen möchtest.",
+  "IMPORTANT_INFO_TEXT": "Wichtige Informationen",
   "USER_MANAGEMENT_CONFIRM_DELETE_NOT_ALLOWED": "Bitte löschen Sie alle ausstehenden Aufgaben/Rollen/Spuren, bevor Sie den Benutzer löschen."
 }

--- a/frontend/libs/portal/i18n/locales/en.json
+++ b/frontend/libs/portal/i18n/locales/en.json
@@ -2098,5 +2098,6 @@
   "DENIED_LICENSES_MSG": "There is no acceptable license option listed for this component. Please investigate if further licensing options are available or replace the component.",
   "EQUAL_WEIGHT_LICENSES_MSG": "No recommendation is possible because the license evaluation is equal.",
   "UNASSERTED_LICENSES_MSG": "The license \"{license}\" has an unasserted status and has not been included in this comparison. Please investigate the license information and update the SBOM if you want to consider it.",
+  "IMPORTANT_INFO_TEXT": "Important Information",
   "USER_MANAGEMENT_CONFIRM_DELETE_NOT_ALLOWED": "Please delete pending tasks/roles/traces before deleting user"
 }


### PR DESCRIPTION
**Refactor LicenseRuleDialog to two-column layout**

The dialog previously displayed all fields in a single column, making it hard to distinguish input fields from contextual information.

 * Split dialog into a left column (form inputs) and a right column (hints & verification) separated by a vertical divider
 * Increased dialog width to accommodate the two-column layout
 * Moved alerts and the verification checkbox to the right column to visually separate "what to fill in" from "what to be aware of"