### PR TITLE
chore(ci): fix go related workflows

### DIFF
--- a/.github/workflows/backend-govulncheck.yml
+++ b/.github/workflows/backend-govulncheck.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ vars.GOLANG_VERSION }}
+          go-version-file: 'go.mod'
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/backend-govulncheck.yml
+++ b/.github/workflows/backend-govulncheck.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'backend/go.mod'
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/backend-govulncheck.yml
+++ b/.github/workflows/backend-govulncheck.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'backend/go.mod'
+          cache-dependency-path: 'backend/go.sum'
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -5,14 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        required: false
-        description: 'Test Backend'
 
 defaults:
   run:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'backend/go.mod'
+          cache-dependency-path: 'backend/go.sum'
       - name: Run tests
         run: |
           go test -v ./...

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ vars.GOLANG_VERSION }}
+          go-version-file: 'go.mod'
       - name: Run tests
         run: |
           go test -v ./...

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'backend/go.mod'
       - name: Run tests
         run: |
           go test -v ./...


### PR DESCRIPTION
Fixed the workflows, that uses `setup-go` Github action and failed, when running on a PR from a fork. The main modification was, to use `go-version-file` instead of `go-version`. Additionally removed unused inputs from `workflow_dispatch` trigger and fixed the caching issue in `setup-go`.

Fixes #116 