### PR TITLE
feat: open component details directly from License Decision Dialog

### DIFF
--- a/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
+++ b/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
@@ -22,6 +22,7 @@ import {computed, ref} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {VForm} from 'vuetify/components';
 import {escapeHtml} from '@disclosure-portal/utils/Validation';
+import DCActionButton from '@shared/components/disco/DCActionButton.vue';
 
 interface LicenseItemWithPolicyStatus {
   id: string;
@@ -38,11 +39,15 @@ const {info} = useSnackbar();
 const rules = useRules();
 const sbomStore = useSbomStore();
 const userStore = useUserStore();
-const emit = defineEmits(['reload']);
+const emit = defineEmits<{
+  reload: [];
+  triggerComponentDetails: [spdxId: string];
+}>();
 const projectStore = useProjectStore();
 
 const form = ref<VForm | null>(null);
 const isVisible = ref(false);
+const isDirectOpen = ref(false);
 
 const selectedComponent = ref<ComponentInfoSlim | undefined>(undefined);
 
@@ -148,8 +153,10 @@ const open = async (
     licenseRecommended: '',
     licenseRecommendedMsg: '',
   },
+  directOpen: boolean = false,
 ) => {
   config.value = newConfig;
+  isDirectOpen.value = directOpen;
   await loadAndPrefillData();
   isVisible.value = true;
 };
@@ -249,12 +256,26 @@ const formatText = (text: string): string => {
   return text;
 };
 
+const closeAndTriggerComponentDetails = () => {
+  close();
+  emit('triggerComponentDetails', selectedComponent.value?.spdxId ?? '');
+};
+
 defineExpose({open});
 </script>
 
 <template>
   <v-dialog v-model="isVisible" width="1200" persistent>
     <DialogLayout :config="dialogConfig" @primary-action="doDialogAction" @secondary-action="close" @close="close">
+      <template #left>
+        <DCActionButton
+          v-if="isDirectOpen"
+          size="small"
+          is-dialog-button
+          @click="closeAndTriggerComponentDetails"
+          :text="t('BTN_COMPONENT_DETAILS')" />
+      </template>
+
       <v-form ref="form" @submit.prevent="doDialogAction">
         <Stack class="gap-4">
           <Stack direction="row" class="items-start gap-4">

--- a/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
@@ -240,6 +240,13 @@ const customKeySort = {
   },
 };
 
+const findComponentAndShowDetails = (spdxId: string) => {
+  const component = componentList.value.find((item) => item.spdxId === spdxId);
+  if (component) {
+    showDetails(component);
+  }
+};
+
 const showDetails = async (item: TabelItem) => {
   idle.show();
 
@@ -272,13 +279,16 @@ const openLicenseRuleDialog = (item: TabelItem) => {
   component.version = item.version;
   component.licenseExpression = item.licenseEffective;
 
-  licenseRuleDialog.value?.open({
-    licenseId: '',
-    component: component,
-    policyStatus: item.policyRuleStatus,
-    licenseRecommended: item.licenseRecommended,
-    licenseRecommendedMsg: item.licenseRecommendedMsg,
-  });
+  licenseRuleDialog.value?.open(
+    {
+      licenseId: '',
+      component: component,
+      policyStatus: item.policyRuleStatus,
+      licenseRecommended: item.licenseRecommended,
+      licenseRecommendedMsg: item.licenseRecommendedMsg,
+    },
+    true,
+  );
 };
 
 const openPolicyDecisionDialog = (item: TabelItem, type: DecisionType): void => {
@@ -774,7 +784,7 @@ onUnmounted(async () => {
     ref="newComponentDetailsDlg"
     @reloadAfterCreation="reload"
     @triggerBulk="openBulkPolicyDecisionsDialog" />
-  <LicenseRuleDialog ref="licenseRuleDialog" @reload="reload" />
+  <LicenseRuleDialog ref="licenseRuleDialog" @reload="reload" @triggerComponentDetails="findComponentAndShowDetails" />
   <PolicyDecisionDialog ref="policyDecisionDialog" @reload="reload" @triggerBulk="openBulkPolicyDecisionsDialog" />
   <BulkPolicyDecisionsDialog ref="bulkPolicyDecisionsDialog" @reload="reload" />
 </template>

--- a/frontend/libs/portal/i18n/locales/de.json
+++ b/frontend/libs/portal/i18n/locales/de.json
@@ -2091,5 +2091,6 @@
   "EQUAL_WEIGHT_LICENSES_MSG": "Keine Empfehlung möglich, da Lizenzbewertung gleich ist.",
   "UNASSERTED_LICENSES_MSG": "Die Lizenz \"{license}\" hat den Status „nicht zugeordnet“ und wurde daher nicht in diesen Vergleich einbezogen. Bitte prüfe die Lizenzinformationen und aktualisiere die SBOM, wenn du diese Lizenz berücksichtigen möchtest.",
   "IMPORTANT_INFO_TEXT": "Wichtige Informationen",
+  "BTN_COMPONENT_DETAILS": "Komponenten Details",
   "USER_MANAGEMENT_CONFIRM_DELETE_NOT_ALLOWED": "Bitte löschen Sie alle ausstehenden Aufgaben/Rollen/Spuren, bevor Sie den Benutzer löschen."
 }

--- a/frontend/libs/portal/i18n/locales/en.json
+++ b/frontend/libs/portal/i18n/locales/en.json
@@ -2099,5 +2099,6 @@
   "EQUAL_WEIGHT_LICENSES_MSG": "No recommendation is possible because the license evaluation is equal.",
   "UNASSERTED_LICENSES_MSG": "The license \"{license}\" has an unasserted status and has not been included in this comparison. Please investigate the license information and update the SBOM if you want to consider it.",
   "IMPORTANT_INFO_TEXT": "Important Information",
+  "BTN_COMPONENT_DETAILS": "Component details",
   "USER_MANAGEMENT_CONFIRM_DELETE_NOT_ALLOWED": "Please delete pending tasks/roles/traces before deleting user"
 }


### PR DESCRIPTION
* The License Decision Dialog now supports a `directOpen` mode: when opened from the component list, the "Component Details" button is shown and navigates back directly to the respective component via its `spdxId`.

* The `triggerComponentDetails` event now carries the `spdxId`, which `TabComponentList` uses to find the component and open its detail view without additional navigation.

* Added i18n key `BTN_COMPONENT_DETAILS` for `EN` and `DE`.