### PR TITLE
feat: restrict license selection to `allow`/`warn` items in License Decision Dialog

### DIFF
--- a/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
+++ b/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
@@ -97,6 +97,17 @@ function getLicenseRecommendationWeight(id: string): number | null {
   return licenseRecommendationWeightMap.value.get(id) ?? null;
 }
 
+const hasSelectableLicenses = computed(() =>
+  licenses.value.some((l) => l.policyType === 'allow' || l.policyType === 'warn'),
+);
+
+const isLicenseDisabled = (policyType: string) =>
+  hasSelectableLicenses.value && policyType !== 'allow' && policyType !== 'warn';
+
+const licenseItemProps = (item: LicenseItemWithPolicyStatus) => ({
+  disabled: isLicenseDisabled(item.policyType),
+});
+
 const licenses = computed((): LicenseItemWithPolicyStatus[] => {
   if (!componentLicenses.value) {
     return [];
@@ -174,9 +185,9 @@ const loadAndPrefillData = async () => {
 
   const licenseIdToSelect = config.value.licenseId || config.value.licenseRecommended;
 
-  selectedLicense.value = licenseIdToSelect
-    ? licenses.value.find((license) => license.id === licenseIdToSelect)
-    : undefined;
+  const candidate = licenseIdToSelect ? licenses.value.find((license) => license.id === licenseIdToSelect) : undefined;
+
+  selectedLicense.value = candidate && isLicenseDisabled(candidate.policyType) ? undefined : candidate;
 };
 
 const loadLicenses = async () => {
@@ -294,6 +305,7 @@ defineExpose({open});
                 :label="t('LICENSE_DECISION')"
                 :disabled="!selectedComponent"
                 :items="licenses"
+                :item-props="licenseItemProps"
                 return-object
                 item-title="name"
                 :loading="licensesLoading"

--- a/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
+++ b/frontend/libs/portal/components/dialog/LicenseRuleDialog.vue
@@ -185,7 +185,7 @@ const loadAndPrefillData = async () => {
 
   const licenseIdToSelect = config.value.licenseId || config.value.licenseRecommended;
 
-  const candidate = licenseIdToSelect ? licenses.value.find((license) => license.id === licenseIdToSelect) : undefined;
+  const candidate = licenses.value.find((license) => license.id === licenseIdToSelect);
 
   selectedLicense.value = candidate && isLicenseDisabled(candidate.policyType) ? undefined : candidate;
 };


### PR DESCRIPTION
* In the license decision dropdown, items with a policy type other than `allow` or `warn` are now disabled for selection when at least one `allow` or `warn` license is available.
* The pre-selection logic follows the same rule: a previously stored or recommended license is only pre-selected if it qualifies as `allow` or `warn` under this condition.