### PR TITLE
chore(ci): fix node related workflows

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v6
         continue-on-error: true
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: 'frontend/.nvmrc'
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run format:check

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -4,14 +4,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        required: false
-        description: 'Test Frontend'
 
 defaults:
    run:

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v6
         continue-on-error: true
         with:
-          node-version-file: 'frontend/.nvmrc'
+          node-version-file: 'frontend/package.json'
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run format:check


### PR DESCRIPTION
The PR triggered workflow `client-test.yml` used a GH actions variable in order to install `node` using GH action `actions/setup-node`. This variable is not accessible, when the workflow is triggered by the `pull_request trigger` for a PR from a fork. Therefore the workflow was changed and the `node` version is no longer determined by the GH actions variable but further more from the `package.json` file.

Fixes #125 