### PR TITLE
chore: update node version to 24 in Dockerfile.build

### DIFF
--- a/frontend/Dockerfile.build
+++ b/frontend/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 
 ARG APP
 ENV NODE_OPTIONS="--max-old-space-size=4096"

--- a/frontend/libs/shared/components/Markdown.vue
+++ b/frontend/libs/shared/components/Markdown.vue
@@ -3,7 +3,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <template>
-  <Markdown class="markdown" html :source="markdownText" />
+  <div>
+    <Markdown class="markdown" html :source="markdownText" />
+    <slot />
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
We already have updated node to version 24 in frontend's `package.json` and `.nvmrc`, but missed to update the version in frontend's `Dockerfile.build`. This was updated accordingly.

During testing, we observed, that the terms of use could not be accepted, the checkbox and the `AGREE` button stayed disabled although we scrolled down completly. This was due to a bug in `Markdown.vue`, which is also fixed with this PR.

Fixes #141