### PR TITLE
Open in new tab with external urls

### DIFF
--- a/frontend/libs/shared/utils/url.ts
+++ b/frontend/libs/shared/utils/url.ts
@@ -3,5 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const openUrlInNewTab = (url: string, features?: string) => {
-  window.open('#' + url, '_blank', features);
+  const isExternalUrl = url.startsWith('http://') || url.startsWith('https://');
+  window.open(`${isExternalUrl ? '' : '#'}${url}`, '_blank', features);
 };


### PR DESCRIPTION
This should fix Prod Bug opening external Project Link with wrong url.