### PR TITLE
show noassertion if attribute is not set (Frontend)

### DIFF
--- a/frontend/libs/portal/components/dialog/ComponentCompareDialog.vue
+++ b/frontend/libs/portal/components/dialog/ComponentCompareDialog.vue
@@ -235,8 +235,8 @@ export default defineComponent({
         componentDetails.value.push(
           new ComponentCompareDetails(
             'License Declared',
-            diffWrapper.licenseDeclared,
-            diffWrapper.getOtherComponent().licenseDeclared,
+            diffWrapper.licenseDeclared || 'NOASSERTION',
+            diffWrapper.getOtherComponent().licenseDeclared || 'NOASSERTION',
             diffWrapper.diff.LicenseDeclared,
             DiffType.value,
           ),
@@ -244,8 +244,8 @@ export default defineComponent({
         componentDetails.value.push(
           new ComponentCompareDetails(
             'License Concluded',
-            diffWrapper.license,
-            diffWrapper.getOtherComponent().license,
+            diffWrapper.license || 'NOASSERTION',
+            diffWrapper.getOtherComponent().license || 'NOASSERTION',
             diffWrapper.diff.License,
             DiffType.value,
           ),
@@ -253,8 +253,8 @@ export default defineComponent({
         componentDetails.value.push(
           new ComponentCompareDetails(
             'License Effective',
-            diffWrapper.licenseEffective,
-            diffWrapper.getOtherComponent().licenseEffective,
+            diffWrapper.licenseEffective || 'NOASSERTION',
+            diffWrapper.getOtherComponent().licenseEffective || 'NOASSERTION',
             diffWrapper.diff.LicenseEffective,
             DiffType.value,
           ),

--- a/frontend/libs/portal/components/dialog/ComponentDetailsDialog.vue
+++ b/frontend/libs/portal/components/dialog/ComponentDetailsDialog.vue
@@ -396,6 +396,15 @@ const getLicenseEffectiveAttribute = (attributes: Details[]) => {
   return foundAttribute ? foundAttribute.Value : 'NOASSERTION';
 };
 
+const NOASSERTION_KEYS = new Set(['licenseEffective', 'licenseConcluded', 'licenseDeclared']);
+
+const getAttributeDisplayValue = (item: LocalDetails): string => {
+  if (NOASSERTION_KEYS.has(item.Key) && !item.Value) {
+    return 'NOASSERTION';
+  }
+  return item.Value;
+};
+
 const dialogLayoutConfig = computed(() => {
   const desc =
     description.value !== 'NOASSERTION'
@@ -788,12 +797,12 @@ defineExpose({
 
               <template #[`item.Value`]="{item}">
                 <DExternalLink v-if="item?.url" :url="item.Value" :text="item.Value" />
-                <span v-else>{{ item.Value }}</span>
+                <span v-else>{{ getAttributeDisplayValue(item) }}</span>
               </template>
 
               <template #[`item.action`]="{item}">
                 <div class="opacity-40 hover:opacity-100">
-                  <DCopyClipboardButton :hint="t('TT_COPY_TO_CLIPBOARD')" :content="item.Value" />
+                  <DCopyClipboardButton :hint="t('TT_COPY_TO_CLIPBOARD')" :content="getAttributeDisplayValue(item)" />
                 </div>
               </template>
             </v-data-table>

--- a/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabComponentList.vue
@@ -753,17 +753,17 @@ onUnmounted(async () => {
           </template>
           <template v-slot:[`item.licenseEffective`]="{item}">
             <span>
-              <span v-html="formatText(item.licenseEffective)"></span>
+              <span v-html="formatText(item.licenseEffective || 'NOASSERTION')"></span>
               <Tooltip>
                 <div class="max-w-[500px]">
                   <div>{{ t('COL_SPDX_LICENSE_EFFECTIVE') }}:</div>
-                  <div class="mr-2" v-html="formatText(item.licenseEffective)"></div>
+                  <div class="mr-2" v-html="formatText(item.licenseEffective || 'NOASSERTION')"></div>
                   <br />
                   <div>{{ t('COL_SPDX_LICENSE_DECLARED') }}:</div>
-                  <div class="mr-2">{{ item.licenseDeclared }}</div>
+                  <div class="mr-2" v-html="formatText(item.licenseDeclared || 'NOASSERTION')"></div>
                   <br />
                   <div>{{ t('COL_SPDX_LICENSE_CONCLUDED') }}:</div>
-                  <div class="mr-2">{{ item.license }}</div>
+                  <div class="mr-2" v-html="formatText(item.license || 'NOASSERTION')"></div>
                   <br />
                   <span>{{ item.usedPolicyRule }} (based on {{ item.licenseApplied }})</span>
                 </div>

--- a/frontend/libs/portal/components/projects/projectsVersions/TabSBOMCompare.vue
+++ b/frontend/libs/portal/components/projects/projectsVersions/TabSBOMCompare.vue
@@ -571,13 +571,16 @@ const getTableViewDataForLicenseEffective = (
 };
 
 const componentInfoToCellValueLicense = (comp: ComponentInfo, icon: string): CellValueWithLicenseInformation => {
+  const licenseEffective = comp.licenseEffective || 'NOASSERTION';
+  const licenseDeclared = comp.licenseDeclared || 'NOASSERTION';
+  const license = comp.license || 'NOASSERTION';
   return new CellValueWithLicenseInformation(
-    comp.licenseEffective,
+    licenseEffective,
     comp.version,
     icon,
-    comp.licenseEffective,
-    comp.licenseDeclared,
-    comp.license,
+    licenseEffective,
+    licenseDeclared,
+    license,
     comp.usedPolicyRule,
     comp.licenseApplied,
   );


### PR DESCRIPTION
## Show NOASSERTION for empty license fields in component views

### Summary

According to the SPDX specification, an absent `licenseConcluded` or `licenseDeclared` field implies `NOASSERTION`. This PR ensures the UI consistently reflects that semantics instead of displaying an empty string.

### Changes

**`TabComponentList.vue`**
- Table cell for `licenseEffective`: falls back to `NOASSERTION` when value is empty
- Tooltip entries for `licenseEffective`, `licenseDeclared`, and `licenseConcluded` (`license`): all fall back to `NOASSERTION`

**`ComponentCompareDialog.vue`**
- `License Declared`, `License Concluded`, and `License Effective` entries in the compare table now fall back to `NOASSERTION` when empty

**`TabSBOMCompare.vue`**
- Applied the fallback centrally in `componentInfoToCellValueLicense` so that `licenseEffective`, `licenseDeclared`, and `license` all resolve to `NOASSERTION` before being passed into `CellValueWithLicenseInformation`, covering both the table cell and the tooltip without requiring template changes

### Motivation

Previously, components with no license information set in the SBOM showed blank cells and blank tooltip entries, which was misleading. The SPDX 2.x standard mandates that a missing value is semantically equivalent to `NOASSERTION`, and this is already how the backend and the `ComponentDetailsDialog` attributes tab handle the case. This PR brings the remaining views in line with that behaviour.

### Testing

- Upload an SBOM where one or more packages have no `licenseConcluded` / `licenseDeclared` set
- Verify that the component list table, the SBOM compare table, and the component compare dialog all display `NOASSERTION` instead of an empty string for those fields
- Verify that packages with an actual license value are unaffected
