### PR TITLE
Show no assertion when attribute is not set (Backend - favored)

### DIFF
--- a/backend/domain/project/spdx_file.go
+++ b/backend/domain/project/spdx_file.go
@@ -219,8 +219,8 @@ func ExtractComponentInfo(componentInfo *[]components.ComponentInfo, componentTy
 		*componentInfo = append(*componentInfo, components.ComponentInfo{
 			SpdxId:            value.Get("SPDXID").String(),
 			Name:              name,
-			License:           value.Get("licenseConcluded").String(),
-			LicenseDeclared:   value.Get("licenseDeclared").String(),
+			License:           getOrNoAssertion(value.Get("licenseConcluded")),
+			LicenseDeclared:   getOrNoAssertion(value.Get("licenseDeclared")),
 			LicenseComments:   value.Get("licenseComments").String(),
 			Version:           version,
 			CopyrightText:     value.Get("copyrightText").String(),
@@ -263,4 +263,11 @@ func (entity *SpdxFileBase) ExtractMetaInfo(spdxString string) {
 		CreationData:    value[6].String(),
 		HasExternalRefs: refs,
 	}
+}
+
+func getOrNoAssertion(result gjson.Result) string {
+	if !result.Exists() {
+		return "NOASSERTION"
+	}
+	return result.String()
 }

--- a/backend/infra/service/componentDetails/details.go
+++ b/backend/infra/service/componentDetails/details.go
@@ -197,6 +197,9 @@ func getAttributes(details map[string]json.RawMessage) (res []project.Detail) {
 	for _, copy := range copyAttributes {
 		rawValue, ok := details[copy]
 		value := ""
+		if !ok && (copy == "licenseDeclared" || copy == "licenseConcluded") {
+			value = "NOASSERTION"
+		}
 		if ok {
 			if copy == "licenseInfoFromFiles" {
 				var values []string
@@ -227,6 +230,9 @@ func getAttributes(details map[string]json.RawMessage) (res []project.Detail) {
 				err := json.Unmarshal(rawValue, &value)
 				exception.HandleErrorServerMessage(err, message.GetI18N(message.UnmarshallingSpdxContent))
 			}
+		}
+		if value == "" && (copy == "licenseDeclared" || copy == "licenseConcluded") {
+			value = "NOASSERTION"
 		}
 		res = append(res, project.Detail{
 			Key:   copy,


### PR DESCRIPTION
# fix: show NOASSERTION when licenseConcluded or licenseDeclared is missing

## Summary

According to the SPDX specification, `licenseConcluded` and `licenseDeclared` are mandatory fields.
When they are absent or empty in an uploaded SPDX file, the system should fall back to `NOASSERTION` rather than displaying an empty string.

## Changes

### `backend/domain/project/spdx_file.go`
- Added helper `getOrNoAssertion` that returns `"NOASSERTION"` when a `gjson.Result` field does not exist in the SPDX JSON
- Applied it to `licenseConcluded` and `licenseDeclared` when extracting `ComponentInfo` at parse time

### `backend/infra/service/componentDetails/details.go`
- Added fallback to `"NOASSERTION"` in `getAttributes` for two cases:
  - The key is entirely absent from the raw JSON map
  - The key is present but its value unmarshals to an empty string

## Why two separate fixes?

`spdx_file.go` operates on the parsed domain object (`ComponentInfo`) used for license rule evaluation.
`details.go` operates on the raw `map[string]json.RawMessage` stored in `ComponentDetails` for the UI detail panel.
These are independent code paths reading the same source data, so both need the NOASSERTION fallback.

