### PR TITLE
fix: noassertion caching issue

### DIFF
--- a/backend/domain/project/components/rest.go
+++ b/backend/domain/project/components/rest.go
@@ -135,8 +135,8 @@ func (entity *ComponentResult) ToComponentInfoDto(
 		Name:                       entity.Component.Name,
 		Version:                    entity.Component.Version,
 		LicenseEffective:           entity.Component.EffectiveLicensesString(),
-		License:                    entity.Component.License,
-		LicenseDeclared:            entity.Component.LicenseDeclared,
+		License:                    orNoAssertion(entity.Component.License),
+		LicenseDeclared:            orNoAssertion(entity.Component.LicenseDeclared),
 		LicenseComments:            entity.Component.LicenseComments,
 		WorstFamily:                string(entity.Component.WorstFamily()),
 		CopyrightText:              entity.Component.CopyrightText,
@@ -212,7 +212,6 @@ func recommendLicense(
 
 	if len(denies) > 0 {
 		return nil, new(message.DeniedLicensesMsg)
-
 	}
 
 	return nil, nil
@@ -383,4 +382,11 @@ func ToUnmatchedDto(unmatched []*UnmatchedLicense) []*UnmatchedLicenseDto {
 		})
 	}
 	return dtos
+}
+
+func orNoAssertion(s string) string {
+	if s == "" {
+		return "NOASSERTION"
+	}
+	return s
 }


### PR DESCRIPTION
After introducing `NOASSERTION` as the display value for missing `licenseDeclared` / `licenseConcluded` fields, an inconsistency was observed under certain circumstances: the component details ATTRIBUTES tab correctly showed `NOASSERTION`, but the component list tooltip still showed an empty string for SBOMs that had been uploaded before the change.

The root cause is that the two views are served by two completely separate backend code paths:

- **ATTRIBUTES tab** (`ComponentDetailsDialog.vue` → details API) always reads the raw SPDX file directly and applies an explicit `NOASSERTION` fallback on every request — so it was always correct.
- **Component list tooltip** (`TabComponentList.vue` → component list API) reads a pre-computed `ComponentInfoList` from a potentially persistent cache. That cache was written at upload time with empty strings, before `getOrNoAssertion()` was introduced. The cache is never fully re-parsed after upload; only license-rule and license-ref enrichment is re-applied when its hash changes. As a result, old SBOMs retained empty strings in the cache indefinitely.

This inconsistency **is not** reproducible when the `cache/` directory only lives inside the container filesystem (no volume mount), so restarting the backend container after a code update wiped all cache files and forced a full re-parse through the updated `getOrNoAssertion()` code.

---

This was fixed by adding an `orNoAssertion()` helper in `domain/project/components/rest.go` and applied it to the `License` (licenseConcluded) and `LicenseDeclared` fields when constructing `ComponentInfoDto`. This makes the component list API resilient to stale cache entries regardless of when the SBOM was originally uploaded, without requiring any cache invalidation or re-upload.

