### PR TITLE
chore(infra)!: replace CouchDB with DocumentDB in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,19 +47,19 @@ services:
       timeout: 5s
       retries: 5
   db:
-    image: couchdb
-    environment:
-      - COUCHDB_USER=admin
-      - COUCHDB_PASSWORD=password
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
     ports:
-      - 5984:5984
+      - 10260:10260
+    command:
+      ["--skip-init-data", "--username", "disuko", "--password", "disuko"]
     volumes:
-      - couchdb_data:/opt/couchdb/data
+      - documentdb_data:/data
     healthcheck:
-      test: curl db:5984/_up
-      interval: 1s
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 9712 -U documentdb -d postgres"]
+      interval: 30s
       timeout: 10s
-      retries: 10
+      start_period: 30s
+      retries: 5
   client:
     build:
       context: ./frontend
@@ -102,12 +102,13 @@ services:
       keycloak:
         condition: service_healthy
     environment:
-      - DATABASE_TYPE=CouchDB
+      - DATABASE_TYPE=MongoDB
       - DATABASE_HOST=db
-      - DATABASE_PORT=5984
+      - DATABASE_PORT=10260
       - DATABASE_SCHEME=http
-      - DATABASE_USER=admin
-      - DATABASE_PASSWORD=password
+      - DATABASE_USER=disuko
+      - DATABASE_PASSWORD=disuko
+      - DATABASE_SKIP_VERIFY=true
       - CACHE_HOST=valkey
       - DISUKO_HOST=https://localhost:3009
       - SERVER_PORT=3009
@@ -134,5 +135,5 @@ services:
       retries: 25
 
 volumes:
-  couchdb_data:
+  documentdb_data:
   keycloak_data:


### PR DESCRIPTION
# Replace CouchDB with DocumentDB

Migrates the local development database from CouchDB to [DocumentDB Local](https://github.com/microsoft/documentdb), a MongoDB-compatible document database built on PostgreSQL.

## What changed

- **`docker-compose.yml`**: replaced `couchdb` image with `ghcr.io/documentdb/documentdb/documentdb-local:latest` on port `10260`, updated `server` environment to use `DATABASE_TYPE=MongoDB`, new credentials, and `DATABASE_SKIP_VERIFY=true` for the auto-generated TLS certificate
- Renamed volume `couchdb_data` → `documentdb_data`

## Why `pg_isready` instead of `mongosh` for the healthcheck

DocumentDB Local runs a MongoDB-compatible gateway (port 10260) on top of PostgreSQL (port 9712). The obvious healthcheck would use `mongosh` to ping the gateway — but this causes significant log pollution:

- The gateway enforces TLS using a self-signed auto-generated certificate, so `mongosh` requires `?tls=true&tlsAllowInvalidCertificates=true`
- Every `mongosh` connection unconditionally issues `atlasVersion` and `getParameter` startup probes that DocumentDB does not implement, logging server-side errors on every healthcheck interval — not suppressible

`pg_isready` checks the underlying PostgreSQL socket directly, generates zero log entries, and is already present in the container image. The trade-off is that it does not verify the gateway layer. For local development this is acceptable since the gateway rarely fails independently of PostgreSQL. 

> :warning: BREAKING CHANGE: Data from former docker-compose runs will not be available any longer.
