### PR TITLE
feat: enhance request ApprovableInfo with SBOM toggle (approvable vs. latest) and Supplier data

### DIFF
--- a/backend/domain/approval/approval.go
+++ b/backend/domain/approval/approval.go
@@ -106,6 +106,8 @@ type ProjectApprovable struct {
 	SpdxTag         string
 	SpdxUploaded    *time.Time
 	IsSpdxRecent    bool
+
+	Supplier *string
 }
 
 type Info struct {

--- a/backend/domain/approval/rest.go
+++ b/backend/domain/approval/rest.go
@@ -73,6 +73,7 @@ func (p *ProjectApprovable) ToDto() ProjectApprovableDto {
 		SpdxTag:         p.SpdxTag,
 		SpdxUploaded:    p.SpdxUploaded,
 		IsSpdxRecent:    p.IsSpdxRecent,
+		Supplier:        p.Supplier,
 	}
 }
 
@@ -87,6 +88,7 @@ type ProjectApprovableDto struct {
 	SpdxTag         string                       `json:"spdxtag"`
 	SpdxUploaded    *time.Time                   `json:"spdxUploaded"`
 	IsSpdxRecent    bool                         `json:"isSpdxRecent"`
+	Supplier        *string                      `json:"supplier"`
 }
 
 type ApproveStateDto struct {
@@ -102,14 +104,14 @@ func (s *ApproveState) ToDto() ApproveStateDto {
 }
 
 type ExternalApprovalDto struct {
-	Vehicel        bool      `json:"vehicle"`
+	Vehicle        bool      `json:"vehicle"`
 	State          StateInfo `json:"state"`
 	ApproveComment string    `json:"comment"`
 }
 
 func (ea *ExternalApproval) ToDto() ExternalApprovalDto {
 	return ExternalApprovalDto{
-		Vehicel:        ea.Vehicle,
+		Vehicle:        ea.Vehicle,
 		State:          ea.State,
 		ApproveComment: ea.Comment,
 	}

--- a/backend/infra/rest/project.go
+++ b/backend/infra/rest/project.go
@@ -461,7 +461,9 @@ func (projectHandler *ProjectHandler) ProjectGetApprovableInfo(w http.ResponseWr
 		PolicyDecisionsRepo: projectHandler.PolicyDecisionsRepository,
 	}
 
-	res := as.GetApprovalInfo(pr)
+	takeLatestSbom := len(r.URL.Query().Get("latestSbom")) > 0
+
+	res := as.GetApprovalInfo(pr, takeLatestSbom)
 	dto := res.ToDto()
 
 	for _, appPr := range dto.Projects {

--- a/backend/infra/service/approval/approval.go
+++ b/backend/infra/service/approval/approval.go
@@ -143,7 +143,18 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			logy.Warnf(s.RequestSession, "Child project is marked as deprecated, uuid: %s parent: %s", prKey, pr.Key)
 			continue
 		}
-		if pr.ApprovableSPDX.SpdxKey == "" || pr.ApprovableSPDX.VersionKey == "" || (!includeNoFOSS && pr.IsNoFoss) {
+
+		var supplier *project.ProjectMemberEntity
+		for _, u := range pr.UserManagement.Users {
+			if u.UserType == project.SUPPLIER {
+				supplier = u
+				break
+			}
+		}
+		var supplierUserId *string
+		if supplier != nil {
+			supplierUserId = &supplier.UserId
+		}
 
 		approvableSPDX := &pr.ApprovableSPDX
 		var sbomList *sbomlist.SbomList
@@ -159,6 +170,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 				ProjectName:     pr.Name,
 				CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 				SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
+				Supplier:        supplierUserId,
 			})
 			continue
 		}
@@ -171,6 +183,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 				ProjectName:     pr.Name,
 				CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 				SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
+				Supplier:        supplierUserId,
 			})
 			continue
 		}
@@ -220,7 +233,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			ProjectName:     pr.Name,
 			CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 			SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
-			ApprovableSPDX:  pr.ApprovableSPDX,
+			Supplier:        supplierUserId,
 			ApprovableSPDX:  *approvableSPDX,
 			SpdxName:        sbom.MetaInfo.Name,
 			SpdxTag:         sbom.Tag,

--- a/backend/infra/service/approval/approval.go
+++ b/backend/infra/service/approval/approval.go
@@ -156,7 +156,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			supplierUserId = &supplier.UserId
 		}
 
-		approvableSPDX := pr.ApprovableSPDX
+		approvableSPDX := &pr.ApprovableSPDX
 		var sbomList *sbomlist.SbomList
 		var sbom *project.SpdxFileBase
 
@@ -234,7 +234,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 			SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
 			Supplier:        supplierUserId,
-			ApprovableSPDX:  approvableSPDX,
+			ApprovableSPDX:  *approvableSPDX,
 			SpdxName:        sbom.MetaInfo.Name,
 			SpdxTag:         sbom.Tag,
 			ApprovableStats: sbomStats,
@@ -245,7 +245,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 	return res
 }
 
-func (s *ApprovalService) findLatestSpdx(pr *project.Project) (approvable.ApprovableSPDX, *sbomlist.SbomList, *project.SpdxFileBase) {
+func (s *ApprovalService) findLatestSpdx(pr *project.Project) (*approvable.ApprovableSPDX, *sbomlist.SbomList, *project.SpdxFileBase) {
 	var latest *project.SpdxFileBase
 	var latestSBOMList *sbomlist.SbomList
 	var latestVersionKey string
@@ -272,10 +272,10 @@ func (s *ApprovalService) findLatestSpdx(pr *project.Project) (approvable.Approv
 	}
 
 	if latest == nil {
-		return approvable.ApprovableSPDX{}, nil, nil
+		return nil, nil, nil
 	}
 
-	approvableSpdx := approvable.ApprovableSPDX{
+	approvableSpdx := &approvable.ApprovableSPDX{
 		SpdxKey:     latest.Key,
 		VersionKey:  latestVersionKey,
 		VersionName: latestVersionName,

--- a/backend/infra/service/approval/approval.go
+++ b/backend/infra/service/approval/approval.go
@@ -10,24 +10,24 @@ import (
 	"sort"
 	"time"
 
-	license2 "github.com/eclipse-disuko/disuko/domain/license"
-	"github.com/eclipse-disuko/disuko/helper/hash"
-	"github.com/eclipse-disuko/disuko/infra/repository/licenserules"
-	"github.com/eclipse-disuko/disuko/infra/repository/policydecisions"
-
 	"github.com/eclipse-disuko/disuko/domain/approval"
 	"github.com/eclipse-disuko/disuko/domain/audit"
+	license2 "github.com/eclipse-disuko/disuko/domain/license"
 	"github.com/eclipse-disuko/disuko/domain/project"
+	"github.com/eclipse-disuko/disuko/domain/project/approvable"
 	"github.com/eclipse-disuko/disuko/domain/project/components"
 	"github.com/eclipse-disuko/disuko/domain/project/sbomlist"
 	user2 "github.com/eclipse-disuko/disuko/domain/user"
 	auditHelper "github.com/eclipse-disuko/disuko/helper/audit"
 	"github.com/eclipse-disuko/disuko/helper/exception"
+	"github.com/eclipse-disuko/disuko/helper/hash"
 	"github.com/eclipse-disuko/disuko/helper/message"
 	"github.com/eclipse-disuko/disuko/infra/repository/approvallist"
 	"github.com/eclipse-disuko/disuko/infra/repository/auditloglist"
 	"github.com/eclipse-disuko/disuko/infra/repository/labels"
 	"github.com/eclipse-disuko/disuko/infra/repository/license"
+	"github.com/eclipse-disuko/disuko/infra/repository/licenserules"
+	"github.com/eclipse-disuko/disuko/infra/repository/policydecisions"
 	"github.com/eclipse-disuko/disuko/infra/repository/policyrules"
 	projectRepo "github.com/eclipse-disuko/disuko/infra/repository/project"
 	sbomListRepo "github.com/eclipse-disuko/disuko/infra/repository/sbomlist"
@@ -91,8 +91,8 @@ func (s *ApprovalService) ProcessRandomApprovalUpdate(pr *project.Project, appId
 	return targetApproval
 }
 
-func (s *ApprovalService) GetApprovalInfo(targetProject *project.Project) approval.Info {
-	return s.getApprovalInfo(targetProject, nil, false)
+func (s *ApprovalService) GetApprovalInfo(targetProject *project.Project, takeLatestSbom bool) approval.Info {
+	return s.getApprovalInfo(targetProject, nil, false, takeLatestSbom)
 }
 
 func (s *ApprovalService) AdminAbortRandomApproval(pr *project.Project, app *approval.Approval) {
@@ -106,7 +106,7 @@ func (s *ApprovalService) AdminAbortRandomApproval(pr *project.Project, app *app
 	}
 }
 
-func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projectFilter *[]string, includeNoFOSS bool) approval.Info {
+func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projectFilter *[]string, includeNoFOSS bool, takeLatestSbom bool) approval.Info {
 	res := approval.Info{
 		CompStats: &components.ComponentStats{},
 	}
@@ -144,6 +144,16 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			continue
 		}
 		if pr.ApprovableSPDX.SpdxKey == "" || pr.ApprovableSPDX.VersionKey == "" || (!includeNoFOSS && pr.IsNoFoss) {
+
+		approvableSPDX := &pr.ApprovableSPDX
+		var sbomList *sbomlist.SbomList
+		var sbom *project.SpdxFileBase
+
+		if takeLatestSbom {
+			approvableSPDX, sbomList, sbom = s.findLatestSpdx(pr)
+		}
+
+		if approvableSPDX.SpdxKey == "" || approvableSPDX.VersionKey == "" || (!includeNoFOSS && pr.IsNoFoss) {
 			res.Projects = append(res.Projects, approval.ProjectApprovable{
 				ProjectKey:      pr.Key,
 				ProjectName:     pr.Name,
@@ -152,8 +162,10 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			})
 			continue
 		}
-		sbomList, sbom := s.SpdxRetriever.RetrieveSbomListAndFile(s.RequestSession, pr.ApprovableSPDX.VersionKey, pr.ApprovableSPDX.SpdxKey)
-		if sbom == nil {
+		if !takeLatestSbom {
+			sbomList, sbom = s.SpdxRetriever.RetrieveSbomListAndFile(s.RequestSession, approvableSPDX.VersionKey, approvableSPDX.SpdxKey)
+		}
+		if sbom == nil || sbomList == nil {
 			res.Projects = append(res.Projects, approval.ProjectApprovable{
 				ProjectKey:      pr.Key,
 				ProjectName:     pr.Name,
@@ -192,7 +204,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 		if sbom.TotalStatsHash != nil && *sbom.TotalStatsHash == *currentTotalStatsHash {
 			sbomStats = sbom.Stats
 		} else {
-			compsInfo := s.SpdxService.GetComponentInfos(s.RequestSession, pr, pr.ApprovableSPDX.VersionKey, sbom)
+			compsInfo := s.SpdxService.GetComponentInfos(s.RequestSession, pr, approvableSPDX.VersionKey, sbom)
 			isVehicle := s.ProjectLabelService.HasVehiclePlatformLabel(s.RequestSession, pr)
 			evalRes := compsInfo.EvaluatePolicyRules(rules, policyDecisions, isVehicle, sbom.Uploaded, sbom.Key)
 
@@ -209,6 +221,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 			SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
 			ApprovableSPDX:  pr.ApprovableSPDX,
+			ApprovableSPDX:  *approvableSPDX,
 			SpdxName:        sbom.MetaInfo.Name,
 			SpdxTag:         sbom.Tag,
 			ApprovableStats: sbomStats,
@@ -217,6 +230,44 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 		})
 	}
 	return res
+}
+
+func (s *ApprovalService) findLatestSpdx(pr *project.Project) (*approvable.ApprovableSPDX, *sbomlist.SbomList, *project.SpdxFileBase) {
+	var latest *project.SpdxFileBase
+	var latestSBOMList *sbomlist.SbomList
+	var latestVersionKey string
+	var latestVersionName string
+
+	for _, version := range pr.Versions {
+		if version.Deleted {
+			continue
+		}
+
+		sbomList := s.SBOMListRepo.FindByKey(s.RequestSession, version.Key, false)
+		if sbomList == nil {
+			continue
+		}
+
+		for _, spdx := range sbomList.SpdxFileHistory {
+			if latest == nil || spdx.Uploaded.After(*latest.Uploaded) {
+				latest = spdx
+				latestSBOMList = sbomList
+				latestVersionKey = version.Key
+				latestVersionName = version.Name
+			}
+		}
+	}
+
+	if latest == nil {
+		return nil, nil, nil
+	}
+
+	approvableSpdx := &approvable.ApprovableSPDX{
+		SpdxKey:     latest.Key,
+		VersionKey:  latestVersionKey,
+		VersionName: latestVersionName,
+	}
+	return approvableSpdx, latestSBOMList, latest
 }
 
 func (s *ApprovalService) setTaskDone(username string, app *approval.Approval, taskType user2.TaskType, taskStatus user2.TaskStatus) {

--- a/backend/infra/service/approval/approval.go
+++ b/backend/infra/service/approval/approval.go
@@ -156,7 +156,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			supplierUserId = &supplier.UserId
 		}
 
-		approvableSPDX := &pr.ApprovableSPDX
+		approvableSPDX := pr.ApprovableSPDX
 		var sbomList *sbomlist.SbomList
 		var sbom *project.SpdxFileBase
 
@@ -234,7 +234,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 			CustomerDiffers: pr.CustomerMeta.Diff(targetProject.CustomerMeta),
 			SupplierDiffers: pr.DocumentMeta.Diff(targetProject.DocumentMeta),
 			Supplier:        supplierUserId,
-			ApprovableSPDX:  *approvableSPDX,
+			ApprovableSPDX:  approvableSPDX,
 			SpdxName:        sbom.MetaInfo.Name,
 			SpdxTag:         sbom.Tag,
 			ApprovableStats: sbomStats,
@@ -245,7 +245,7 @@ func (s *ApprovalService) getApprovalInfo(targetProject *project.Project, projec
 	return res
 }
 
-func (s *ApprovalService) findLatestSpdx(pr *project.Project) (*approvable.ApprovableSPDX, *sbomlist.SbomList, *project.SpdxFileBase) {
+func (s *ApprovalService) findLatestSpdx(pr *project.Project) (approvable.ApprovableSPDX, *sbomlist.SbomList, *project.SpdxFileBase) {
 	var latest *project.SpdxFileBase
 	var latestSBOMList *sbomlist.SbomList
 	var latestVersionKey string
@@ -272,10 +272,10 @@ func (s *ApprovalService) findLatestSpdx(pr *project.Project) (*approvable.Appro
 	}
 
 	if latest == nil {
-		return nil, nil, nil
+		return approvable.ApprovableSPDX{}, nil, nil
 	}
 
-	approvableSpdx := &approvable.ApprovableSPDX{
+	approvableSpdx := approvable.ApprovableSPDX{
 		SpdxKey:     latest.Key,
 		VersionKey:  latestVersionKey,
 		VersionName: latestVersionName,

--- a/backend/infra/service/approval/external_approval.go
+++ b/backend/infra/service/approval/external_approval.go
@@ -22,7 +22,7 @@ func (s *ApprovalService) CreateExternalApproval(pr *project.Project, req approv
 		exception.ThrowExceptionBadRequestResponse()
 	}
 
-	info := s.getApprovalInfo(pr, &req.SelectedProjects, false)
+	info := s.getApprovalInfo(pr, &req.SelectedProjects, false, false)
 	if len(info.Projects) == 0 {
 		exception.ThrowExceptionBadRequestResponse()
 	}

--- a/backend/infra/service/approval/internal_approval.go
+++ b/backend/infra/service/approval/internal_approval.go
@@ -30,7 +30,7 @@ func (s *ApprovalService) CreateInternalApproval(pr *project.Project, req approv
 		exception.ThrowExceptionBadRequestResponse()
 	}
 
-	info := s.getApprovalInfo(pr, nil, false)
+	info := s.getApprovalInfo(pr, nil, false, false)
 	if len(info.Projects) == 0 {
 		exception.ThrowExceptionBadRequestResponse()
 	}

--- a/backend/infra/service/approval/plausibility_check.go
+++ b/backend/infra/service/approval/plausibility_check.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *ApprovalService) CreatePlausibilityCheck(pr *project.Project, req approval.RequestPlausibilityCheckDto, creator string) string {
-	info := s.getApprovalInfo(pr, nil, true)
+	info := s.getApprovalInfo(pr, nil, true, false)
 	appr := approval.Approval{
 		ChildEntity: domain.SetChildEntity(uuid.New().String()),
 		Type:        approval.TypePlausibility,


### PR DESCRIPTION
Add two enhancements to approvable info retrieval:

- **SBOM Toggle**: Users can now control whether latest or approvable SBOM is included in approvable information
- **Supplier Information**: Supplier data now available in approvable info retrieval

Related commits:
- feat: add toggle for latest SBOM in approvable info retrieval
- feat: add supplier information to approvable info retrieval