### PR TITLE
ci(github-actions): implement dependency review workflow

### DIFF
--- a/.github/additional-allowed-licenses.txt
+++ b/.github/additional-allowed-licenses.txt
@@ -1,0 +1,2 @@
+# Needed for golang libraries
+LicenseRef-scancode-google-patent-license-golang

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,40 @@
+name: 'Dependency Review'
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v6
+      - name: 'Fetch Eclipse Approved and Valid Licenses'
+        id: eclipse-licenses
+        run: |
+          LICENSES=$(curl -sSf https://www.eclipse.org/legal/licenses/licenses.json \
+            | jq -r '[(.approved, .valid) | keys[]] | join(",")' \
+            | sed 's/UNLICENSE/Unlicense/g')
+          echo "list=${LICENSES}" >> "$GITHUB_OUTPUT"
+      - name: 'Add Additional Allowed Licenses'
+        id: all-allowed-licenses
+        run: |
+          EXTRA=$(grep -v '^\s*$' .github/additional-allowed-licenses.txt | grep -v '^\s*#' | paste -sd ',')
+          BASE="${{ steps.eclipse-licenses.outputs.list }}"
+          if [ -n "$EXTRA" ]; then
+            COMBINED="${BASE},${EXTRA}"
+          else
+            COMBINED="${BASE}"
+          fi
+          echo "list=${COMBINED}" >> "$GITHUB_OUTPUT"
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 #v5.0.0
+        with:
+          allow-licenses: ${{ steps.all-allowed-licenses.outputs.list }}
+          comment-summary-in-pr: always
+          show-patched-versions: true


### PR DESCRIPTION
## Add Dependency Review Workflow

Automates license compliance checks on every PR targeting `main`, enforcing Eclipse Foundation license policy.

### What it does

- Triggers on every pull request targeting `main`
- Fetches approved and valid licenses dynamically from the [Eclipse Foundation license API](https://www.eclipse.org/legal/licenses/licenses.json) — always up to date, no hardcoded list
- Merges project-specific license allowances from `.github/additional-allowed-licenses.txt`
- Runs [`actions/dependency-review-action@v5`](https://github.com/actions/dependency-review-action) pinned to a specific commit SHA for supply chain safety
- Posts a license and vulnerability summary comment directly on the PR
- Shows available patched versions for any vulnerable dependency

### Additional allowed licenses

| License | Reason |
|---|---|
| `LicenseRef-scancode-google-patent-license-golang` | Required for Go standard library dependencies |

### Permissions

Runs with minimal permissions: `contents: read`, `pull-requests: write` (needed for PR comment).